### PR TITLE
docs: clarify parent issue lifecycle management workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
   5. **Design Approval**: Wait for design approval before proceeding
   6. **Breakdown**: Create implementation subtasks linked to design document
   7. **Implement**: Follow TDD practices to build feature
-  8. **Submit Feature**: Create feature PR and move parent Linear issue to "In Review"
+  8. **Submit Subtask**: Create subtask PR and move subtask Linear issue to "In Review"
 
 - **Technical design requirements**
   - Include architectural decisions, API specifications, and high-level approach
@@ -38,6 +38,13 @@
   - Command includes effort estimates using Fibonacci scale (Linear estimation enabled)
   - Target subtasks at 1-5 points for optimal sprint planning
   - All subtasks link to technical design document for context
+
+- **Parent issue lifecycle management**
+  - **Parent issues remain "In Progress" until ALL subtasks are completed**
+  - Only move parent to "In Review" when creating final integration PR that closes the parent
+  - Never move parent to "Done" until it's fully implemented and merged
+  - Design completion does NOT move parent to "Done" - only moves design subtask to "In Review"
+  - Track progress through subtask completion, not parent status changes
 
 #### Project Board Workflow
 - **Todo**: Issues ready to be worked on


### PR DESCRIPTION
## Summary
Clarify parent issue lifecycle management in CLAUDE.md workflow to prevent confusion about when parent issues should be marked as complete.

## Problem
SPI-50 was incorrectly marked as "Done" when only the technical design was complete, while implementation subtasks were still in progress. This created confusion about project status.

## Changes
- **Parent Issue Lifecycle**: Add explicit section stating parent issues remain "In Progress" until ALL subtasks are completed
- **Step 8 Clarification**: Update from "move parent Linear issue to 'In Review'" to "move subtask Linear issue to 'In Review'"  
- **Design vs Implementation**: Clarify that design completion only moves design subtask to "In Review", not the parent
- **Clear Rules**: Establish that parent status should only change when creating final integration PR

## Impact
- Prevents premature parent issue completion
- Improves project tracking accuracy
- Reduces workflow confusion
- Maintains proper Linear board state

🤖 Generated with Claude Code