### PR TITLE
fix(ci): change Release Please release-type from gradle to java

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,8 +21,8 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          # Configure for Gradle/Kotlin project
-          release-type: gradle
+          # Configure for Gradle/Kotlin project (using java type)
+          release-type: java
           package-name: jcvd
           
           # Configure version file - gradle.properties is primary version source (SPI-486)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "gradle",
+  "release-type": "java",
   "packages": {
     ".": {
       "package-name": "jcvd",
-      "release-type": "gradle",
+      "release-type": "java",
       "version-file": "gradle.properties",
       "extra-files": [
         {
-          "type": "gradle",
+          "type": "java",
           "path": "build.gradle.kts",
           "version-key": "version"
         }


### PR DESCRIPTION
## Summary
Fixes the Release Please workflow error by changing the release-type from `gradle` to `java`.

## Problem
After merging the automated release process PR, Release Please failed with:
```
Error: release-please failed: core (spiralhouse/jcvd): Unknown release type: gradle
```

## Solution
Release Please v4 doesn't recognize `gradle` as a valid release type. For Java/Gradle projects, we need to use `java` as the release-type.

## Changes
- Updated `.github/workflows/release-please.yml` to use `release-type: java`
- Updated `release-please-config.json` to use `release-type: java` in both locations
- Updated extra-files type from `gradle` to `java`

## Testing
- ✅ JSON configuration validated successfully
- ✅ This will be tested when merged and Release Please runs again

## Impact
Once merged, Release Please should successfully analyze the repository and create a release PR with version bumps and changelog.

Fixes the immediate blocker for automated releases.

🤖 Generated with Claude Code