### PR TITLE
fix(ci): skip label creation to avoid Release Please permission error

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,6 +54,7 @@ jobs:
           # Additional configuration
           draft: false
           prerelease: false
+          skip-labeling: true  # Skip label creation to avoid permission issues
           
           # Token configuration
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -73,7 +73,8 @@
       "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
       "pull-request-header": "## Summary\n\nThis pull request includes the following changes for the upcoming release:\n\n",
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "skip-labeling": true
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes the non-fatal Release Please error about label creation permissions.

## Context
Release Please successfully created PR #25 but failed at the end with:
```
Error: release-please failed: You do not have permission to create labels on this repository
```

This is because `GITHUB_TOKEN` has limited permissions for creating labels.

## Solution
Added `skip-labeling: true` to:
- `.github/workflows/release-please.yml`
- `release-please-config.json`

This tells Release Please to skip the label creation step entirely.

## Impact
- ✅ Release Please will complete without errors
- ✅ PRs will still be created successfully
- ✅ Just won't have auto-generated labels (which is fine)

## Testing
The next Release Please run after merging this will complete without the label error.

Note: PR #25 (the release PR) is already created and working, this just prevents the error in future runs.

🤖 Generated with Claude Code