### PR TITLE
docs: add Release Please token setup guide and improve workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,7 +57,10 @@ jobs:
           skip-labeling: true  # Skip label creation to avoid permission issues
           
           # Token configuration
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use RELEASE_PLEASE_TOKEN if available (PAT with repo/workflow scopes)
+          # Falls back to GITHUB_TOKEN if not configured
+          # Note: GITHUB_TOKEN won't trigger the release workflow on PR merge
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   # Build and tag container on successful release
   publish-release-container:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,6 +54,7 @@ jobs:
           # Additional configuration
           draft: false
           prerelease: false
+          skip-labeling: true  # Skip label creation to avoid permission issues
           
           # Token configuration
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -4,6 +4,17 @@
 
 JCVD uses a fully automated release process powered by [Release Please](https://github.com/googleapis/release-please) and conventional commits. This approach ensures consistent, reliable releases with minimal manual intervention while maintaining high quality through automated testing and validation.
 
+## Prerequisites
+
+For full automation to work:
+
+1. **Conventional Commits**: All commits must follow the specification
+2. **Release Token**: Configure `RELEASE_PLEASE_TOKEN` secret with PAT (see [Token Setup Guide](./RELEASE_TOKEN_SETUP.md))
+   - Without this token, release workflow won't trigger automatically
+   - Default `GITHUB_TOKEN` has limitations that prevent full automation
+3. **GitHub Actions**: Workflows must be enabled in repository settings
+4. **Container Registry**: Write access to `ghcr.io/spiralhouse/jcvd`
+
 ## Release Strategy
 
 ### Automated Release Philosophy

--- a/docs/RELEASE_TOKEN_SETUP.md
+++ b/docs/RELEASE_TOKEN_SETUP.md
@@ -1,0 +1,100 @@
+# Release Please Token Setup
+
+## Overview
+
+For the automated release process to work fully, Release Please needs a token with sufficient permissions to:
+1. Create pull requests with version bumps
+2. Create GitHub releases
+3. Trigger the release workflow when PRs are merged
+
+## Current Configuration
+
+The Release Please workflow is configured to use tokens in this order:
+1. `RELEASE_PLEASE_TOKEN` (if configured) - Recommended
+2. `GITHUB_TOKEN` (fallback) - Limited functionality
+
+## Token Limitations
+
+### GITHUB_TOKEN (Default)
+The default `GITHUB_TOKEN` provided by GitHub Actions has limitations:
+- ✅ Can create PRs
+- ✅ Can read/write repository contents
+- ❌ Cannot create labels (mitigated with `skip-labeling: true`)
+- ❌ **Cannot trigger other workflows** (critical limitation)
+
+**Important**: When using `GITHUB_TOKEN`, merging a Release Please PR will NOT trigger the release workflow that publishes artifacts and containers.
+
+### Personal Access Token (Recommended)
+A PAT with proper scopes can:
+- ✅ Create PRs and releases
+- ✅ Create labels
+- ✅ **Trigger other workflows** (enables full automation)
+
+## Setting Up RELEASE_PLEASE_TOKEN
+
+### Step 1: Create a Personal Access Token
+
+1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+2. Click "Generate new token (classic)"
+3. Give it a descriptive name: `Release Please Token for JCVD`
+4. Set expiration (recommend 90 days with calendar reminder to rotate)
+5. Select scopes:
+   - `repo` (Full control of private repositories)
+   - `workflow` (Update GitHub Action workflows)
+6. Click "Generate token"
+7. **Copy the token immediately** (you won't see it again)
+
+### Step 2: Add Token to Repository Secrets
+
+1. Go to your repository on GitHub
+2. Navigate to Settings → Secrets and variables → Actions
+3. Click "New repository secret"
+4. Name: `RELEASE_PLEASE_TOKEN`
+5. Value: Paste the token from Step 1
+6. Click "Add secret"
+
+### Step 3: Verify Setup
+
+After adding the token, the next push to main will use it automatically. You can verify by:
+1. Checking the Release Please workflow logs
+2. Confirming that merging a Release Please PR triggers the release workflow
+
+## Security Best Practices
+
+1. **Token Rotation**: Set a calendar reminder to rotate the token before expiration
+2. **Minimal Scopes**: Only grant `repo` and `workflow` scopes
+3. **Use GitHub App**: For production/organization use, consider a GitHub App instead of PAT
+4. **Audit Access**: Regularly review who has access to repository secrets
+
+## Alternative: GitHub App
+
+For organization-wide usage, consider creating a GitHub App instead of using a PAT:
+- Better security (app-specific permissions)
+- No expiration issues
+- Clearer audit trail
+- Can be shared across multiple repositories
+
+See [GitHub Apps documentation](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps) for setup instructions.
+
+## Troubleshooting
+
+### Release workflow not triggering
+- **Symptom**: Release Please PR merges but release workflow doesn't run
+- **Cause**: Using `GITHUB_TOKEN` instead of PAT
+- **Solution**: Set up `RELEASE_PLEASE_TOKEN` as described above
+
+### Permission errors
+- **Symptom**: "Resource not accessible by integration" errors
+- **Cause**: Token missing required scopes
+- **Solution**: Ensure token has both `repo` and `workflow` scopes
+
+### Token expiration
+- **Symptom**: Release Please suddenly stops working
+- **Cause**: PAT expired
+- **Solution**: Generate new token and update secret
+
+## Current Status
+
+- ✅ Release Please workflow configured to use `RELEASE_PLEASE_TOKEN` if available
+- ✅ Falls back to `GITHUB_TOKEN` for basic functionality
+- ⚠️ Full automation requires `RELEASE_PLEASE_TOKEN` to be configured

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -73,7 +73,8 @@
       "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
       "pull-request-header": "## Summary\n\nThis pull request includes the following changes for the upcoming release:\n\n",
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "skip-labeling": true
     }
   }
 }


### PR DESCRIPTION
## Summary
Improves the Release Please workflow to support custom tokens and adds comprehensive documentation about token setup.

## Context
The default `GITHUB_TOKEN` has limitations:
- Cannot trigger other workflows (critical for release automation)
- Cannot create labels (though we've mitigated this with `skip-labeling`)

This means when a Release Please PR is merged, the release workflow won't automatically trigger to publish artifacts.

## Changes

### Workflow Enhancement
- Modified `release-please.yml` to support `RELEASE_PLEASE_TOKEN` with fallback to `GITHUB_TOKEN`
- Added clear comments about token limitations

### Documentation
- Created `docs/RELEASE_TOKEN_SETUP.md` with:
  - Step-by-step PAT creation guide
  - Security best practices
  - Troubleshooting section
  - Alternative GitHub App approach
- Updated `docs/RELEASE_PROCESS.md` to reference token setup in prerequisites

## Impact
- **With PAT configured**: Full automation - Release Please PR merge triggers release workflow
- **Without PAT**: Limited automation - Manual workflow trigger needed after PR merge
- **Backward compatible**: Falls back to GITHUB_TOKEN if PAT not configured

## Recommendation
After merging this PR, follow the guide in `docs/RELEASE_TOKEN_SETUP.md` to set up `RELEASE_PLEASE_TOKEN` for full automation.

🤖 Generated with Claude Code