### PR TITLE
fix: container build JAR path issue

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -618,7 +618,7 @@ jobs:
         with:
           name: build-artifacts-${{ needs.version.outputs.version }}
           path: |
-            build/libs/
+            build/libs/*.jar
             build/distributions/
           retention-days: 30
 
@@ -646,13 +646,22 @@ jobs:
       - name: Verify JAR exists before container build
         run: |
           echo "🔍 Verifying JAR exists before Docker build..."
-          if [[ ! -f "build/libs/jcvd-server.jar" ]]; then
-            echo "❌ JAR file not found: build/libs/jcvd-server.jar"
-            echo "Available files in build/libs/:"
-            ls -la build/libs/ || echo "build/libs/ directory does not exist"
+          
+          # Check for JAR in expected location
+          if [[ -f "build/libs/jcvd-server.jar" ]]; then
+            echo "✅ JAR file verified: $(du -h build/libs/jcvd-server.jar)"
+          # Check if artifact download created nested structure (legacy fix)
+          elif [[ -f "build/libs/libs/jcvd-server.jar" ]]; then
+            echo "⚠️ Found JAR in nested structure, moving to correct location..."
+            mv build/libs/libs/*.jar build/libs/
+            rmdir build/libs/libs
+            echo "✅ JAR file moved and verified: $(du -h build/libs/jcvd-server.jar)"
+          else
+            echo "❌ JAR file not found!"
+            echo "Contents of build/libs/:"
+            ls -la build/libs/ 2>/dev/null || echo "build/libs/ directory does not exist"
             exit 1
           fi
-          echo "✅ JAR file verified: $(du -h build/libs/jcvd-server.jar)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Problem
The container build job is failing because the JAR file is not found at the expected path.

## Root Cause
The artifact upload action uploads the entire `build/libs/` directory. When this is downloaded to `build/libs/`, it creates a nested structure: `build/libs/libs/jcvd-server.jar`.

## Solution
1. **Primary fix**: Changed artifact upload to only upload `*.jar` files instead of the entire directory
2. **Fallback logic**: Added handling for nested structure if it occurs (moves files to correct location)

## Testing
The fix includes defensive coding to handle both scenarios:
- Normal case: JAR is at `build/libs/jcvd-server.jar`
- Legacy case: JAR is at `build/libs/libs/jcvd-server.jar` (moves it to correct location)

This ensures the container build will succeed regardless of the artifact structure.