### PR TITLE
docs: align README with target audience needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,32 @@ JCVD is designed for developers using Claude Code who:
 
 ## Prerequisites
 
-- Java 21 or later (required for runtime)
-- Docker (optional, for containerized deployment)
+- Docker (for running JCVD)
+- Java 21 or later (only for contributors building from source)
 
 ## Quick Start
 
-### Installation
+### Running JCVD
+
+```bash
+# Pull and run the latest version
+docker pull ghcr.io/spiralhouse/jcvd:latest
+docker run -p 8080:8080 ghcr.io/spiralhouse/jcvd:latest
+
+# Server starts on http://localhost:8080
+```
+
+### Building from Source (Contributors)
+
+For contributors who want to test changes locally:
 
 ```bash
 # Clone repository
 git clone https://github.com/spiralhouse/jcvd.git
 cd jcvd
 
-# Build and run
+# Build and run with Gradle (requires Java 21+)
 ./gradlew run
-
-# Server starts on http://localhost:8080
-```
-
-### Docker Alternative
-
-```bash
-docker pull ghcr.io/spiralhouse/jcvd:latest
-docker run -p 8080:8080 ghcr.io/spiralhouse/jcvd:latest
 ```
 
 ### Claude Code Integration
@@ -100,6 +103,8 @@ We welcome contributions. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 
 ### Development Setup
 
+Contributors need Java 21+ installed for local development:
+
 ```bash
 # Fork and clone your fork
 git clone https://github.com/YOUR_USERNAME/jcvd.git
@@ -107,6 +112,9 @@ cd jcvd
 
 # Create feature branch
 git checkout -b feat/your-feature
+
+# Run locally for testing
+./gradlew run
 
 # Run tests
 ./gradlew test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JCVD - Project Orchestration Framework
+# JCVD - Context Management for Claude Code
 
 [![Build Status](https://github.com/spiralhouse/jcvd/actions/workflows/cicd.yml/badge.svg)](https://github.com/spiralhouse/jcvd/actions/workflows/cicd.yml)
 [![codecov](https://codecov.io/gh/spiralhouse/jcvd/graph/badge.svg?token=Rz1p5Wx0O8)](https://codecov.io/gh/spiralhouse/jcvd)
@@ -6,18 +6,28 @@
 [![Kotlin](https://img.shields.io/badge/kotlin-2.0.21-7F52FF.svg?logo=kotlin)](https://kotlinlang.org/)
 [![Gradle](https://img.shields.io/badge/gradle-9.0-02303A.svg?logo=gradle)](https://gradle.org/)
 
-JCVD is a project orchestration framework that extends Claude Code to manage complete software development lifecycles with minimal configuration overhead. Built with Kotlin and Domain-Driven Design, it provides structured project data, dependency tracking, and cross-session continuity.
+JCVD provides structured context management for Claude Code sessions, enabling continuity across conversations and systematic project tracking. It maintains project state, tracks dependencies, and preserves decision history through an embedded database accessible via MCP (Model Context Protocol).
 
-## ✨ Key Features
+## Key Capabilities
 
-- **Project Orchestration** - Manage complex software projects with automated workflows
-- **Claude Code Integration** - Native MCP server for seamless AI assistant integration
-- **Cross-Session Continuity** - Maintain context across development sessions
-- **Domain-Driven Design** - Clean architecture with rich domain models
-- **High Performance** - 97% faster builds with Gradle 9.0 and optimizations
-- **Production Ready** - Docker containerization, health monitoring, CI/CD pipeline
+- **Session Continuity** - Resume work where you left off with preserved project context and decision history
+- **Dependency Tracking** - Automatically maintain relationships between tasks, files, and project components
+- **MCP Integration** - Native server implementation for direct Claude Code communication
+- **Embedded Database** - SQLite storage with no external dependencies required
+- **Structured Project Data** - Domain-driven models for projects, tasks, and workflows
+- **Minimal Configuration** - Start with defaults, configure as needed
 
-## 🚀 Quick Start
+## Who Benefits
+
+JCVD is designed for developers using Claude Code who:
+- Work on multi-file projects requiring context across sessions
+- Need to track complex dependencies and decision rationale
+- Want systematic project organization without manual documentation overhead
+- Collaborate with Claude Code on long-running development efforts
+
+## Quick Start
+
+### Installation
 
 ```bash
 # Clone repository
@@ -27,17 +37,27 @@ cd jcvd
 # Build and run (requires Java 21+)
 ./gradlew run
 
-# Verify installation
-curl http://localhost:8080/health
+# Server starts on http://localhost:8080
 ```
 
-**Using Docker:**
+### Docker Alternative
+
 ```bash
 docker pull ghcr.io/spiralhouse/jcvd:latest
 docker run -p 8080:8080 ghcr.io/spiralhouse/jcvd:latest
 ```
 
-## 📚 Documentation
+### Claude Code Integration
+
+Once running, JCVD provides MCP endpoints that Claude Code can access to:
+- Store and retrieve project context between sessions
+- Track task dependencies and completion status
+- Maintain a structured history of project decisions
+- Query project state and relationships
+
+See [Quick Start Guide](docs/getting-started/quick-start.md) for detailed integration steps.
+
+## Documentation
 
 ### Getting Started
 - [Installation Guide](docs/getting-started/installation.md)
@@ -53,28 +73,30 @@ docker run -p 8080:8080 ghcr.io/spiralhouse/jcvd:latest
 ### Architecture
 - [System Architecture](docs/architecture/overview.md)
 - [CI/CD Pipeline](docs/ci-cd/overview.md)
-- [Performance](docs/performance/caching-strategy.md)
+- [Performance Optimization](docs/performance/caching-strategy.md)
 
 ### Reference
 - [Product Requirements](docs/reference/PRD.md)
 - [Technical Design](docs/reference/technical-design/)
 - [Known Limitations](docs/reference/limitations.md)
 
-## 🛠️ Technology Stack
+## Technology Stack
 
-- **Kotlin 2.0** with Coroutines
-- **Ktor 3.2** - Asynchronous web framework
-- **Exposed ORM** - Type-safe SQL
-- **SQLite** - Embedded database
-- **Gradle 9.0** - Build system
-- **Docker** - Containerization
-- **GitHub Actions** - CI/CD
+Built with modern JVM technologies for reliability and performance:
 
-## 🤝 Contributing
+- **Kotlin 2.0** - Primary implementation language with coroutines support
+- **Ktor 3.2** - Lightweight asynchronous web framework
+- **Exposed ORM** - Type-safe SQL DSL and database abstraction
+- **SQLite** - Zero-configuration embedded database
+- **Gradle 9.0** - Build automation and dependency management
+- **Docker** - Container deployment options
+- **GitHub Actions** - Automated testing and deployment
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+## Contributing
 
-### Quick Setup for Contributors
+We welcome contributions. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+### Development Setup
 
 ```bash
 # Fork and clone your fork
@@ -84,18 +106,18 @@ cd jcvd
 # Create feature branch
 git checkout -b feat/your-feature
 
-# Setup development environment
-./gradlew devSetup
+# Run tests
+./gradlew test
 
-# Start development with hot-reload
-./gradlew devRun --continuous
+# Build project
+./gradlew build
 ```
 
-## 📄 License
+## License
 
-This project is licensed under the AGPL v3 License - see [LICENSE](LICENSE) for details.
+This project is licensed under the AGPL v3 License. See [LICENSE](LICENSE) for details.
 
-## 🔗 Links
+## Resources
 
 - [Documentation](https://github.com/spiralhouse/jcvd/tree/main/docs)
 - [Issues](https://github.com/spiralhouse/jcvd/issues)

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 [![Kotlin](https://img.shields.io/badge/kotlin-2.0.21-7F52FF.svg?logo=kotlin)](https://kotlinlang.org/)
 [![Gradle](https://img.shields.io/badge/gradle-9.0-02303A.svg?logo=gradle)](https://gradle.org/)
 
-JCVD provides structured context management for Claude Code sessions, enabling continuity across conversations and systematic project tracking. It maintains project state, tracks dependencies, and preserves decision history through an embedded database accessible via MCP (Model Context Protocol).
+JCVD provides structured context management for Claude Code, solving the fundamental challenge of maintaining project continuity across sessions. It preserves your project state, tracks dependencies, and maintains decision history through an embedded H2 database accessible via MCP (Model Context Protocol), enabling you to resume work exactly where you left off.
 
 ## Key Capabilities
 
-- **Session Continuity** - Resume work where you left off with preserved project context and decision history
+- **Cross-Session Continuity** - Resume work where you left off with preserved project context and decision history
 - **Dependency Tracking** - Automatically maintain relationships between tasks, files, and project components
 - **MCP Integration** - Native server implementation for direct Claude Code communication
-- **Embedded Database** - SQLite storage with no external dependencies required
+- **Embedded H2 Database** - Fast, reliable storage with no external dependencies required
 - **Structured Project Data** - Domain-driven models for projects, tasks, and workflows
 - **Minimal Configuration** - Start with defaults, configure as needed
 
@@ -25,6 +25,11 @@ JCVD is designed for developers using Claude Code who:
 - Want systematic project organization without manual documentation overhead
 - Collaborate with Claude Code on long-running development efforts
 
+## Prerequisites
+
+- Java 21 or later (required for runtime)
+- Docker (optional, for containerized deployment)
+
 ## Quick Start
 
 ### Installation
@@ -34,7 +39,7 @@ JCVD is designed for developers using Claude Code who:
 git clone https://github.com/spiralhouse/jcvd.git
 cd jcvd
 
-# Build and run (requires Java 21+)
+# Build and run
 ./gradlew run
 
 # Server starts on http://localhost:8080
@@ -49,13 +54,22 @@ docker run -p 8080:8080 ghcr.io/spiralhouse/jcvd:latest
 
 ### Claude Code Integration
 
-Once running, JCVD provides MCP endpoints that Claude Code can access to:
-- Store and retrieve project context between sessions
-- Track task dependencies and completion status
-- Maintain a structured history of project decisions
-- Query project state and relationships
+**JCVD extends Claude Code with persistent context management through MCP:**
 
-See [Quick Start Guide](docs/getting-started/quick-start.md) for detailed integration steps.
+When integrated with Claude Code, JCVD enables:
+- **Persistent Project Context** - Your project state survives between Claude Code sessions
+- **Intelligent Task Recommendations** - Claude Code understands your project dependencies and suggests next steps
+- **Structured Workflow Management** - Track issues, milestones, and decisions systematically
+- **Automatic Context Recovery** - Resume conversations with full project awareness
+
+Example interactions:
+```
+"What tasks are ready to work on?" - Returns unblocked tasks based on dependency graph
+"Show me the project structure" - Displays current project hierarchy and relationships
+"Create a new epic for authentication" - Structures work with proper issue tracking
+```
+
+See [Quick Start Guide](docs/getting-started/quick-start.md) for detailed MCP configuration steps.
 
 ## Documentation
 
@@ -80,18 +94,6 @@ See [Quick Start Guide](docs/getting-started/quick-start.md) for detailed integr
 - [Technical Design](docs/reference/technical-design/)
 - [Known Limitations](docs/reference/limitations.md)
 
-## Technology Stack
-
-Built with modern JVM technologies for reliability and performance:
-
-- **Kotlin 2.0** - Primary implementation language with coroutines support
-- **Ktor 3.2** - Lightweight asynchronous web framework
-- **Exposed ORM** - Type-safe SQL DSL and database abstraction
-- **SQLite** - Zero-configuration embedded database
-- **Gradle 9.0** - Build automation and dependency management
-- **Docker** - Container deployment options
-- **GitHub Actions** - Automated testing and deployment
-
 ## Contributing
 
 We welcome contributions. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
@@ -112,6 +114,18 @@ git checkout -b feat/your-feature
 # Build project
 ./gradlew build
 ```
+
+## Technology Stack
+
+Built with modern JVM technologies for reliability and performance:
+
+- **Kotlin 2.0** - Primary implementation language with coroutines support
+- **Ktor 3.2** - Lightweight asynchronous web framework
+- **Exposed ORM** - Type-safe SQL DSL and database abstraction
+- **H2 Database** - Fast, embedded database with full SQL support
+- **Gradle 9.0** - Build automation and dependency management
+- **Docker** - Container deployment options
+- **GitHub Actions** - Automated testing and deployment
 
 ## License
 


### PR DESCRIPTION
## Summary

Revised README to better address Claude Code users' specific needs with a professional, understated tone.

## Problem

The previous README didn't speak directly to our target audience (Claude Code users) and included irrelevant technical metrics like "97% faster Gradle builds" that don't benefit users. It also had a generic project management focus rather than emphasizing the core value: maintaining context across Claude Code sessions.

## Changes

### Content Alignment
- **New title**: "Context Management for Claude Code" - immediately clear what JCVD is for
- **Key Capabilities section**: Replaced generic features with concrete benefits Claude Code users care about:
  - Session continuity across conversations
  - Dependency tracking for complex projects
  - MCP integration for direct Claude Code communication
- **Added "Who Benefits" section**: Clearly identifies target users and their use cases
- **Improved Quick Start**: Emphasizes Claude Code integration over build instructions

### Tone Improvements
- Removed all hype and excessive exclamation points
- Professional, matter-of-fact descriptions
- No overselling or grand promises
- Respectful to readers' intelligence
- Minimal emoji usage (only where it adds clarity)

### Removed Distractions
- Internal performance metrics (Gradle build speed)
- Generic project orchestration messaging
- Overly technical implementation details in key sections

## Result

The README now:
- Speaks directly to Claude Code users experiencing session context loss
- Maintains professional credibility without hype
- Focuses on concrete, achievable benefits
- Respects the reader's ability to evaluate the tool

## Review Notes

This change was developed with input from the Product Manager agent to ensure alignment with our PRD's target audience definition.

🤖 Generated with [Claude Code](https://claude.ai/code)