### PR TITLE
feat: add personality to Claude GitHub code reviewer

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,20 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Read code reviewer personality
+        id: read-personality
+        run: |
+          if [ -f .claude/agents/code-reviewer.md ]; then
+            # Read the file content and store in environment variable
+            {
+              echo 'REVIEWER_PERSONALITY<<EOF'
+              cat .claude/agents/code-reviewer.md
+              echo 'EOF'
+            } >> $GITHUB_ENV
+          else
+            echo "REVIEWER_PERSONALITY=Please review this pull request and provide constructive feedback." >> $GITHUB_ENV
+          fi
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@beta
@@ -47,18 +61,10 @@ jobs:
           # model: "claude-opus-4-1-20250805"
 
           # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Be constructive and helpful in your feedback.
+          direct_prompt: ${{ env.REVIEWER_PERSONALITY }}
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          # Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
+          use_sticky_comment: true
           
           # Optional: Customize review based on file types
           # direct_prompt: |


### PR DESCRIPTION
## Summary
- Injects custom personality from `.claude/agents/code-reviewer.md` into Claude's code reviews
- Enables sticky comments to reduce PR comment spam
- Improves developer experience with our skeptical but encouraging review style

## Changes
### Workflow Enhancement
- **Personality Injection**: Reads our custom code reviewer personality file
- **Dynamic Prompt**: Passes personality content to `direct_prompt` parameter
- **Sticky Comments**: Enabled to update single comment instead of creating multiple
- **Safe Content Handling**: Uses GitHub environment variables for proper escaping

### Implementation Details
- Added "Read code reviewer personality" step in workflow
- Uses heredoc pattern for safe multiline content handling
- Includes fallback text if personality file doesn't exist
- Preserves all existing workflow functionality

## Benefits
- ✅ Code reviews now use our custom personality (skeptical but encouraging)
- ✅ Single updating comment instead of comment spam
- ✅ Consistent review style across all PRs
- ✅ Better developer experience with constructive feedback

## Testing
The implementation:
- Properly reads the personality file content
- Safely handles multiline text and special characters
- Maintains valid YAML syntax
- Falls back gracefully if file is missing

## Note
This PR will demonstrate its own feature - Claude's review of this PR will use the new personality configuration! 🎭

## Closes
- Fixes #SPI-533

🤖 Generated with [Claude Code](https://claude.ai/code)