### PR TITLE
fix: update Claude workflow permissions for PR operations

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,11 +24,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      contents: write       # Required for Claude to push commits to PR branches
+      pull-requests: write  # Required for Claude to comment on and modify PRs
+      issues: write         # Required for Claude to comment on and manage issues
+      id-token: write       # Required for OIDC authentication
+      actions: read         # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Updated GitHub workflow permissions to enable Claude Code to properly interact with pull requests
- Changed permissions from read-only to write where necessary for PR operations

## Changes
- **contents**: `read` → `write` - Enables pushing commits to PR branches
- **pull-requests**: `read` → `write` - Enables commenting on and modifying PRs  
- **issues**: `read` → `write` - Enables commenting on and managing issues

## Context
The previous read-only permissions prevented the claude-code-action from:
- Commenting on pull requests
- Pushing commits to PR branches
- Managing issue comments and status

These permissions align with the requirements documented in the [anthropics/claude-code-action setup guide](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md).

## Test Plan
- [ ] Verify Claude can comment on this PR when mentioned with @claude
- [ ] Verify Claude can push commits when requested in PR comments
- [ ] Verify workflow triggers correctly on PR events

🤖 Generated with [Claude Code](https://claude.ai/code)