### PR TITLE
feat(ci): enhance workflow concurrency controls to cancel duplicate runs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -44,8 +44,11 @@ on:
         default: 'false'
 
 # Enhanced concurrency control to prevent duplicate runs and save resources
+# This will cancel any in-progress runs when a new push is made to the same branch
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  # Use PR number for pull requests, branch name for pushes
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel previous runs on the same branch when a new one starts
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,9 +11,12 @@ on:
     #   - "build.gradle.kts"
     #   - "settings.gradle.kts"
 
-# Prevent duplicate Claude review runs
+# Prevent duplicate Claude review runs on the same PR
+# This will cancel any in-progress review when a new commit is pushed to the PR
 concurrency:
-  group: claude-review-${{ github.head_ref || github.ref }}
+  # Group by PR number to ensure only one review runs per PR at a time
+  group: claude-review-pr-${{ github.event.pull_request.number }}
+  # Cancel previous review when new commits are pushed
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,9 +10,12 @@ on:
   pull_request_review:
     types: [submitted]
 
-# Prevent duplicate Claude Code runs
+# Prevent duplicate Claude Code runs on the same issue/PR
+# This will cancel any in-progress Claude interactions when a new one starts
 concurrency:
-  group: claude-code-${{ github.head_ref || github.ref }}-${{ github.event_name }}
+  # Group by issue/PR number and event type to allow one interaction per context
+  group: claude-code-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event_name }}
+  # Cancel previous Claude interaction when a new comment is made
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -39,9 +39,12 @@ on:
         required: false
         type: string
 
-# Concurrency control to prevent simultaneous promotions
+# Concurrency control to prevent simultaneous promotions to the same environment
+# Production promotions should never be cancelled, hence cancel-in-progress is false
 concurrency:
+  # Group by target environment to prevent conflicting deployments
   group: promote-${{ github.event.inputs.target_env }}
+  # Never cancel in-progress promotions (especially critical for production)
   cancel-in-progress: false
 
 permissions:

--- a/docs/ci-cd/concurrency-control.md
+++ b/docs/ci-cd/concurrency-control.md
@@ -1,0 +1,133 @@
+# CI/CD Workflow Concurrency Control
+
+## Overview
+
+All GitHub Actions workflows in CycleTime are configured with concurrency controls to prevent duplicate runs, save CI resources, and ensure clean deployment paths. This document explains the concurrency strategy for each workflow.
+
+## Concurrency Configuration by Workflow
+
+### 1. CI/CD Pipeline (`cicd.yml`)
+
+```yaml
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```
+
+**Strategy:**
+- Groups runs by PR number (for pull requests) or branch reference (for pushes)
+- Cancels in-progress runs when new commits are pushed to the same branch/PR
+- Saves CI resources by avoiding redundant test runs on outdated commits
+
+**Benefits:**
+- Faster feedback on latest commits
+- Reduced CI queue times
+- Lower GitHub Actions usage costs
+
+### 2. Claude Code Review (`claude-code-review.yml`)
+
+```yaml
+concurrency:
+  group: claude-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+```
+
+**Strategy:**
+- Groups reviews by PR number to ensure one review per PR at a time
+- Cancels previous review when new commits are pushed to the PR
+- Ensures reviews are always based on the latest code
+
+**Benefits:**
+- Avoids conflicting or outdated code reviews
+- Reduces API usage for Claude reviews
+- Provides timely feedback on latest changes
+
+### 3. Claude Code Assistant (`claude.yml`)
+
+```yaml
+concurrency:
+  group: claude-code-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event_name }}
+  cancel-in-progress: true
+```
+
+**Strategy:**
+- Groups interactions by issue/PR number and event type
+- Cancels previous Claude interactions when new comments trigger it
+- Maintains context separation between different issues/PRs
+
+**Benefits:**
+- Prevents Claude from processing outdated requests
+- Ensures responses are based on latest context
+- Reduces confusion from overlapping interactions
+
+### 4. Environment Promotion (`promote.yml`)
+
+```yaml
+concurrency:
+  group: promote-${{ github.event.inputs.target_env }}
+  cancel-in-progress: false  # Critical: Never cancel promotions
+```
+
+**Strategy:**
+- Groups promotions by target environment (staging, production)
+- **Never cancels in-progress promotions** (critical for deployment safety)
+- Ensures only one promotion to each environment at a time
+
+**Benefits:**
+- Prevents conflicting deployments to the same environment
+- Maintains deployment integrity and audit trail
+- Protects production from interrupted deployments
+
+## Key Design Decisions
+
+### 1. Cancel-in-Progress Settings
+
+- **CI/CD, Claude workflows:** `cancel-in-progress: true`
+  - Safe to cancel as they're idempotent operations
+  - Latest code/comment is always most relevant
+  
+- **Promotion workflow:** `cancel-in-progress: false`
+  - Deployments must complete to maintain system state
+  - Cancellation could leave environments in unknown state
+
+### 2. Grouping Strategies
+
+- **PR-based grouping:** Used for PR-triggered workflows to maintain PR isolation
+- **Branch-based grouping:** Used for push events to handle direct commits
+- **Environment-based grouping:** Used for deployments to prevent conflicts
+
+### 3. Resource Optimization
+
+The concurrency controls help optimize GitHub Actions usage:
+- Reduce unnecessary compute time on outdated commits
+- Minimize API calls to external services (Claude)
+- Prevent resource waste from redundant builds
+
+## Best Practices
+
+1. **Always test concurrency behavior** after workflow changes
+2. **Monitor cancelled runs** in GitHub Actions tab for patterns
+3. **Document exceptions** if cancel-in-progress needs to be disabled
+4. **Use descriptive group names** that clearly indicate the isolation boundary
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Workflow not cancelling previous runs:**
+   - Check if group name is correctly formed
+   - Verify cancel-in-progress is set to true
+
+2. **Production deployments being cancelled:**
+   - Ensure promote.yml has `cancel-in-progress: false`
+   - Check for manual workflow cancellations
+
+3. **Multiple workflows running for same PR:**
+   - Verify PR number is being correctly extracted
+   - Check for different event types triggering separate groups
+
+## Related Documentation
+
+- [GitHub Actions Concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency)
+- [CI/CD Pipeline Overview](./overview.md)
+- [Release Process](./release-process.md)


### PR DESCRIPTION
## Summary
- Enhanced concurrency configuration for all GitHub Actions workflows
- Improved grouping strategies to better handle PR and branch-based runs
- Added comprehensive documentation for the concurrency control strategy

## Changes
- **CI/CD Pipeline**: Groups by PR number or branch ref for better isolation
- **Claude Code Review**: Groups by PR number to ensure one review per PR
- **Claude Code Assistant**: Groups by issue/PR number and event type
- **Environment Promotion**: Maintains `cancel-in-progress: false` for safety
- **Documentation**: Added detailed concurrency control documentation

## Benefits
- 🚀 Faster CI feedback by cancelling outdated runs
- 💰 Reduced GitHub Actions usage and costs  
- 🔄 Prevents duplicate work on the same branch/PR
- 🛡️ Maintains deployment safety (promotions never cancelled)

## Test Plan
- [x] Verified all workflow YAML files are valid
- [x] Confirmed concurrency group expressions are correct
- [x] Tested that promotion workflow keeps cancel-in-progress: false
- [ ] Will be validated when PR triggers CI runs

Fixes #SPI-568