### PR TITLE
fix(ci): Fix claude-code-action PR context for automated reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0  # Full history for better diff analysis
 
       - name: Read code reviewer personality
         id: read-personality
@@ -60,5 +60,19 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          prompt: ${{ env.REVIEWER_PERSONALITY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            
+            Please review this pull request with the following personality and approach:
+            
+            ${{ env.REVIEWER_PERSONALITY }}
+            
+            Note: The PR branch is already checked out in the current working directory.
+            
+            Use `gh pr comment` for top-level feedback.
+            Only post GitHub comments - don't submit review text as messages.
+          use_sticky_comment: true
+          claude_args: |
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 


### PR DESCRIPTION
## Summary

This PR fixes the claude-code-action workflow that wasn't posting PR review comments. The action was failing because it didn't have the necessary PR context.

## Problem

The claude-code-action was only posting to workflow summaries, not as PR comments. When checking the workflow logs, Claude was asking "What PR would you like me to review?" indicating it lacked context.

## Solution

- Added explicit PR context (`REPO` and `PR NUMBER`) to the prompt
- Enabled sticky comments for PR posting
- Configured allowed tools for PR review operations  
- Set full fetch depth for better diff analysis

## Impact

Once merged, the claude-code-action will:
- Know which PR to review
- Post comments directly to PRs
- Have access to necessary GitHub CLI tools for proper code review

This needs to be merged separately so that other PRs (like #57) can benefit from the fixed workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)