### PR TITLE
feat(mcp): Add WebSocket infrastructure layer - Phase 3/9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.ktor.server.di)
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.server.sse)
+    implementation(libs.ktor.server.websockets)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.server.cors)
     implementation(libs.ktor.server.call.logging)
@@ -94,6 +95,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.ktor.server.test.host)
     testImplementation("io.ktor:ktor-client-content-negotiation:${libs.versions.ktor.get()}")
+    testImplementation("io.ktor:ktor-client-websockets:${libs.versions.ktor.get()}")
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.h2.database)  // H2 for integration testing
 

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/server/MCPConfiguration.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/server/MCPConfiguration.kt
@@ -1,0 +1,97 @@
+package io.spiralhouse.cycletime.mcp.server
+
+import io.spiralhouse.cycletime.domain.services.BuildInfo
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Centralized configuration for MCP server and integration.
+ * 
+ * This configuration class provides:
+ * - Single source of truth for MCP settings
+ * - Environment variable override support
+ * - Performance tuning parameters
+ * - Production-ready defaults
+ */
+data class MCPConfiguration(
+    // Connection settings
+    val host: String = System.getenv("MCP_HOST") ?: "0.0.0.0",
+    val port: Int = System.getenv("MCP_PORT")?.toIntOrNull() ?: 8080,
+    val path: String = System.getenv("MCP_PATH") ?: "/mcp",
+    val enabled: Boolean = System.getenv("MCP_ENABLED")?.toBoolean() ?: true,
+    
+    // WebSocket settings
+    val pingPeriod: Duration = System.getenv("MCP_PING_PERIOD")?.toLongOrNull()?.milliseconds ?: 30.seconds,
+    val timeout: Duration = System.getenv("MCP_TIMEOUT")?.toLongOrNull()?.milliseconds ?: 15.seconds,
+    val maxFrameSize: Long = System.getenv("MCP_MAX_FRAME_SIZE")?.toLongOrNull() ?: (10 * 1024 * 1024), // 10MB
+    val masking: Boolean = System.getenv("MCP_MASKING")?.toBoolean() ?: false,
+    
+    // Performance settings
+    val maxConnections: Int = System.getenv("MCP_MAX_CONNECTIONS")?.toIntOrNull() ?: 100,
+    val connectionBufferSize: Int = System.getenv("MCP_BUFFER_SIZE")?.toIntOrNull() ?: 8192,
+    val asyncProcessingEnabled: Boolean = System.getenv("MCP_ASYNC_ENABLED")?.toBoolean() ?: true,
+    val requestTimeout: Duration = System.getenv("MCP_REQUEST_TIMEOUT")?.toLongOrNull()?.milliseconds ?: 60.seconds,
+    
+    // Resource caching
+    val resourceCacheEnabled: Boolean = System.getenv("MCP_CACHE_ENABLED")?.toBoolean() ?: true,
+    val resourceCacheTtl: Duration = System.getenv("MCP_CACHE_TTL")?.toLongOrNull()?.milliseconds ?: 5.seconds,
+    val resourceCacheMaxSize: Int = System.getenv("MCP_CACHE_MAX_SIZE")?.toIntOrNull() ?: 100,
+    
+    // Monitoring settings
+    val metricsEnabled: Boolean = System.getenv("MCP_METRICS_ENABLED")?.toBoolean() ?: true,
+    val slowRequestThreshold: Duration = System.getenv("MCP_SLOW_REQUEST_MS")?.toLongOrNull()?.milliseconds ?: 100.milliseconds,
+    val detailedLogging: Boolean = System.getenv("MCP_DETAILED_LOGGING")?.toBoolean() ?: false,
+    
+    // Server info
+    val serverName: String = System.getenv("MCP_SERVER_NAME") ?: BuildInfo.serviceName,
+    val serverVersion: String = System.getenv("MCP_SERVER_VERSION") ?: BuildInfo.version,
+    val serverDescription: String = System.getenv("MCP_SERVER_DESCRIPTION") ?: BuildInfo.serviceDescription,
+    
+    // Protocol settings
+    val protocolVersion: String = "2024-11-05",
+    val supportedVersions: Set<String> = setOf("2024-11-05")
+) {
+    companion object {
+        /**
+         * Load configuration from environment with validation.
+         */
+        fun fromEnvironment(): MCPConfiguration {
+            val config = MCPConfiguration()
+            config.validate()
+            return config
+        }
+        
+        /**
+         * Create a test configuration with optimized settings.
+         */
+        fun forTesting(): MCPConfiguration = MCPConfiguration(
+            pingPeriod = 5.seconds,
+            timeout = 5.seconds,
+            maxConnections = 10,
+            resourceCacheEnabled = false,
+            metricsEnabled = false,
+            detailedLogging = true
+        )
+    }
+    
+    /**
+     * Validate configuration parameters.
+     */
+    fun validate() {
+        require(port in 1..65535) { "Port must be between 1 and 65535" }
+        require(maxConnections > 0) { "Max connections must be positive" }
+        require(connectionBufferSize > 0) { "Buffer size must be positive" }
+        require(maxFrameSize > 0) { "Max frame size must be positive" }
+        require(resourceCacheMaxSize > 0) { "Cache max size must be positive" }
+        require(path.startsWith("/")) { "Path must start with /" }
+    }
+    
+    /**
+     * Check if performance optimizations are enabled.
+     */
+    fun isOptimized(): Boolean = 
+        asyncProcessingEnabled && 
+        resourceCacheEnabled && 
+        connectionBufferSize >= 8192
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/server/MCPConnectionManager.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/server/MCPConnectionManager.kt
@@ -1,0 +1,320 @@
+package io.spiralhouse.cycletime.mcp.server
+
+import io.ktor.websocket.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.system.measureTimeMillis
+
+/**
+ * Connection information for tracking and monitoring.
+ */
+data class ConnectionInfo(
+    val id: String,
+    val session: WebSocketSession,
+    val connectedAt: Long = System.currentTimeMillis(),
+    var lastActivity: Long = System.currentTimeMillis(),
+    var requestCount: AtomicLong = AtomicLong(0),
+    var errorCount: AtomicInteger = AtomicInteger(0),
+    val metadata: MutableMap<String, Any> = ConcurrentHashMap()
+)
+
+/**
+ * Production-ready WebSocket connection manager with optimized resource management.
+ * 
+ * Features:
+ * - Connection pooling and limits
+ * - Graceful degradation under load
+ * - Memory-efficient frame processing
+ * - Connection health monitoring
+ * - Automatic cleanup of stale connections
+ */
+class MCPConnectionManager(
+    private val config: MCPConfiguration
+) {
+    private val logger = LoggerFactory.getLogger(MCPConnectionManager::class.java)
+    private val connections = ConcurrentHashMap<String, ConnectionInfo>()
+    private val connectionCount = AtomicInteger(0)
+    private val totalRequests = AtomicLong(0)
+    private val totalErrors = AtomicLong(0)
+    private val connectionMutex = Mutex()
+    
+    // Performance metrics
+    private val requestLatencies = mutableListOf<Long>()
+    private val latencyMutex = Mutex()
+    private val maxLatencySamples = 1000
+    
+    // Frame processing optimization
+    private val frameBuffer = Channel<Pair<String, Frame>>(capacity = Channel.BUFFERED)
+    
+    /**
+     * Register a new WebSocket connection.
+     * 
+     * @return Connection ID if accepted, null if rejected
+     */
+    suspend fun registerConnection(session: WebSocketSession): String? {
+        return connectionMutex.withLock {
+            if (connectionCount.get() >= config.maxConnections) {
+                logger.warn("Connection rejected: max connections (${config.maxConnections}) reached")
+                session.close(CloseReason(
+                    CloseReason.Codes.TRY_AGAIN_LATER,
+                    "Server at capacity"
+                ))
+                return null
+            }
+            
+            val connectionId = generateConnectionId()
+            val info = ConnectionInfo(connectionId, session)
+            connections[connectionId] = info
+            connectionCount.incrementAndGet()
+            
+            logger.info("Connection registered: $connectionId (active: ${connectionCount.get()})")
+            connectionId
+        }
+    }
+    
+    /**
+     * Unregister a WebSocket connection.
+     */
+    suspend fun unregisterConnection(connectionId: String) {
+        connectionMutex.withLock {
+            connections.remove(connectionId)?.let { info ->
+                connectionCount.decrementAndGet()
+                val duration = System.currentTimeMillis() - info.connectedAt
+                
+                logger.info(
+                    "Connection unregistered: $connectionId " +
+                    "(duration: ${duration}ms, requests: ${info.requestCount.get()}, " +
+                    "errors: ${info.errorCount.get()}, active: ${connectionCount.get()})"
+                )
+            }
+        }
+    }
+    
+    /**
+     * Process an incoming frame with optimized handling.
+     */
+    suspend fun processFrame(
+        connectionId: String,
+        frame: Frame,
+        handler: suspend (String) -> String
+    ): String? {
+        val connection = connections[connectionId] ?: return null
+        
+        return when (frame) {
+            is Frame.Text -> {
+                val processingTime = measureTimeMillis {
+                    connection.lastActivity = System.currentTimeMillis()
+                    connection.requestCount.incrementAndGet()
+                    totalRequests.incrementAndGet()
+                }
+                
+                try {
+                    val response = measureAndProcess(frame.readText(), handler)
+                    recordLatency(processingTime)
+                    response
+                } catch (e: Exception) {
+                    connection.errorCount.incrementAndGet()
+                    totalErrors.incrementAndGet()
+                    throw e
+                }
+            }
+            is Frame.Binary -> {
+                logger.warn("Binary frames not supported for connection: $connectionId")
+                null
+            }
+            else -> null
+        }
+    }
+    
+    /**
+     * Send a frame to a specific connection with error handling.
+     */
+    suspend fun sendFrame(connectionId: String, frame: Frame): Boolean {
+        val connection = connections[connectionId] ?: return false
+        
+        return try {
+            connection.session.send(frame)
+            connection.lastActivity = System.currentTimeMillis()
+            true
+        } catch (e: CancellationException) {
+            logger.debug("Send cancelled for connection: $connectionId")
+            false
+        } catch (e: Exception) {
+            logger.error("Failed to send frame to connection $connectionId: ${e.message}")
+            connection.errorCount.incrementAndGet()
+            false
+        }
+    }
+    
+    /**
+     * Get current connection statistics.
+     */
+    fun getStatistics(): ConnectionStatistics {
+        val now = System.currentTimeMillis()
+        val activeConnections = connections.values.map { info ->
+            ConnectionStat(
+                id = info.id,
+                duration = now - info.connectedAt,
+                requests = info.requestCount.get(),
+                errors = info.errorCount.get(),
+                lastActivity = now - info.lastActivity
+            )
+        }
+        
+        val avgLatency = if (requestLatencies.isNotEmpty()) {
+            requestLatencies.average().toLong()
+        } else 0L
+        
+        return ConnectionStatistics(
+            activeCount = connectionCount.get(),
+            totalRequests = totalRequests.get(),
+            totalErrors = totalErrors.get(),
+            averageLatency = avgLatency,
+            maxLatency = requestLatencies.maxOrNull() ?: 0L,
+            connections = activeConnections
+        )
+    }
+    
+    /**
+     * Clean up stale connections.
+     */
+    suspend fun cleanupStaleConnections(maxIdle: Duration = Duration.INFINITE) {
+        if (maxIdle == Duration.INFINITE) return
+        
+        val now = System.currentTimeMillis()
+        val staleThreshold = now - maxIdle.inWholeMilliseconds
+        
+        connections.entries.filter { (_, info) ->
+            info.lastActivity < staleThreshold
+        }.forEach { (id, info) ->
+            logger.info("Closing stale connection: $id (idle: ${now - info.lastActivity}ms)")
+            try {
+                info.session.close(CloseReason(
+                    CloseReason.Codes.NORMAL,
+                    "Connection idle timeout"
+                ))
+            } catch (e: Exception) {
+                logger.debug("Error closing stale connection: ${e.message}")
+            }
+            unregisterConnection(id)
+        }
+    }
+    
+    /**
+     * Broadcast a frame to all connections.
+     */
+    suspend fun broadcast(frame: Frame) {
+        connections.values.parallelForEach { info ->
+            try {
+                info.session.send(frame)
+            } catch (e: Exception) {
+                logger.debug("Failed to broadcast to connection ${info.id}: ${e.message}")
+            }
+        }
+    }
+    
+    /**
+     * Check if a connection is healthy.
+     */
+    fun isConnectionHealthy(connectionId: String): Boolean {
+        val info = connections[connectionId] ?: return false
+        val errorRate = if (info.requestCount.get() > 0) {
+            info.errorCount.get().toDouble() / info.requestCount.get()
+        } else 0.0
+        
+        return errorRate < 0.1 // Less than 10% error rate
+    }
+    
+    /**
+     * Close all connections gracefully.
+     */
+    suspend fun closeAll() {
+        logger.info("Closing all ${connections.size} connections")
+        
+        connections.values.parallelForEach { info ->
+            try {
+                info.session.close(CloseReason(
+                    CloseReason.Codes.GOING_AWAY,
+                    "Server shutting down"
+                ))
+            } catch (e: Exception) {
+                logger.debug("Error closing connection ${info.id}: ${e.message}")
+            }
+        }
+        
+        connections.clear()
+        connectionCount.set(0)
+    }
+    
+    // Private helper methods
+    
+    private fun generateConnectionId(): String = 
+        "mcp-${System.currentTimeMillis()}-${(Math.random() * 10000).toInt()}"
+    
+    private suspend fun measureAndProcess(
+        text: String,
+        handler: suspend (String) -> String
+    ): String {
+        val startTime = System.currentTimeMillis()
+        return try {
+            handler(text)
+        } finally {
+            val duration = System.currentTimeMillis() - startTime
+            if (duration > config.slowRequestThreshold.inWholeMilliseconds) {
+                logger.warn("Slow request detected: ${duration}ms")
+            }
+        }
+    }
+    
+    private suspend fun recordLatency(latency: Long) {
+        latencyMutex.withLock {
+            requestLatencies.add(latency)
+            if (requestLatencies.size > maxLatencySamples) {
+                requestLatencies.removeAt(0)
+            }
+        }
+    }
+    
+    private suspend inline fun <T> Collection<T>.parallelForEach(
+        crossinline action: suspend (T) -> Unit
+    ) {
+        kotlinx.coroutines.coroutineScope {
+            forEach { item ->
+                launch {
+                    action(item)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Connection statistics for monitoring.
+ */
+data class ConnectionStatistics(
+    val activeCount: Int,
+    val totalRequests: Long,
+    val totalErrors: Long,
+    val averageLatency: Long,
+    val maxLatency: Long,
+    val connections: List<ConnectionStat>
+)
+
+/**
+ * Individual connection statistics.
+ */
+data class ConnectionStat(
+    val id: String,
+    val duration: Long,
+    val requests: Long,
+    val errors: Int,
+    val lastActivity: Long
+)

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/ConnectionEventListener.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/ConnectionEventListener.kt
@@ -1,0 +1,69 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+/**
+ * Observer interface for connection lifecycle events.
+ * 
+ * Implements the Observer pattern to allow external components to react
+ * to connection events without tight coupling to the connection manager.
+ * 
+ * ## Design Pattern
+ * This follows the Observer pattern where:
+ * - ConnectionManager is the Subject
+ * - ConnectionEventListener implementations are Observers
+ * - Events are pushed to all registered listeners
+ * 
+ * ## Use Cases
+ * - Logging and monitoring
+ * - Analytics and metrics collection
+ * - Resource cleanup on disconnection
+ * - Session state management
+ * - Alert generation for connection issues
+ */
+interface ConnectionEventListener {
+    
+    /**
+     * Called when a new connection is established.
+     * 
+     * @param connection the newly established connection
+     */
+    fun onConnectionEstablished(connection: WebSocketConnection)
+    
+    /**
+     * Called when a connection is closed.
+     * 
+     * @param connectionId the ID of the closed connection
+     * @param reason the reason for closure, if available
+     */
+    fun onConnectionClosed(connectionId: String, reason: String?)
+    
+    /**
+     * Called when a message is received from a connection.
+     * 
+     * @param connectionId the ID of the connection
+     * @param messageSize the size of the message in bytes
+     */
+    fun onMessageReceived(connectionId: String, messageSize: Int)
+    
+    /**
+     * Called when a message is sent to a connection.
+     * 
+     * @param connectionId the ID of the connection
+     * @param messageSize the size of the message in bytes
+     */
+    fun onMessageSent(connectionId: String, messageSize: Int)
+    
+    /**
+     * Called when an error occurs on a connection.
+     * 
+     * @param connectionId the ID of the connection
+     * @param error the error that occurred
+     */
+    fun onConnectionError(connectionId: String, error: Throwable)
+    
+    /**
+     * Called when a connection times out.
+     * 
+     * @param connectionId the ID of the timed-out connection
+     */
+    fun onConnectionTimeout(connectionId: String)
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/ConnectionFactory.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/ConnectionFactory.kt
@@ -1,0 +1,49 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import io.ktor.websocket.DefaultWebSocketSession
+
+/**
+ * Factory interface for creating and configuring connections.
+ * 
+ * This abstraction follows the Factory pattern to encapsulate the creation
+ * logic for connections, allowing for different connection types and
+ * initialization strategies.
+ * 
+ * ## Design Benefits
+ * - Centralized connection creation logic
+ * - Consistent connection initialization
+ * - Support for different connection types
+ * - Testability through mock implementations
+ * 
+ * ## Future Extensibility
+ * Could support:
+ * - Connection pooling
+ * - Different transport protocols
+ * - Custom connection metadata
+ * - Connection recycling
+ */
+interface ConnectionFactory {
+    
+    /**
+     * Creates a new connection wrapper for a WebSocket session.
+     * 
+     * @param session the underlying WebSocket session
+     * @return a new connection wrapper with unique ID and tracking
+     */
+    fun createConnection(session: DefaultWebSocketSession): ActiveWebSocketSession
+    
+    /**
+     * Generates a unique identifier for a new connection.
+     * 
+     * @return a unique connection identifier
+     */
+    fun generateConnectionId(): String
+    
+    /**
+     * Validates if a connection ID is valid.
+     * 
+     * @param connectionId the ID to validate
+     * @return true if the ID is valid, false otherwise
+     */
+    fun isValidConnectionId(connectionId: String): Boolean
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/ConnectionManager.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/ConnectionManager.kt
@@ -1,0 +1,106 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcProtocolHandler
+
+/**
+ * Core interface for managing connections in the MCP server.
+ * 
+ * This abstraction allows for different transport mechanisms beyond WebSocket
+ * (e.g., TCP sockets, named pipes, HTTP long polling) while maintaining
+ * a consistent connection management API.
+ * 
+ * ## Design Principles
+ * - Transport-agnostic connection management
+ * - Lifecycle management with proper resource cleanup
+ * - Support for multiple concurrent connections
+ * - Integration with protocol handlers for message processing
+ * 
+ * ## Implementation Requirements
+ * - Thread-safe connection tracking
+ * - Graceful shutdown with connection cleanup
+ * - Proper error propagation through exceptions
+ * - Resource lifecycle management
+ */
+interface ConnectionManager {
+    
+    /**
+     * Starts the connection manager and begins accepting connections.
+     * 
+     * @throws WebSocketServerException if the server fails to start
+     */
+    suspend fun start()
+    
+    /**
+     * Stops the connection manager and closes all active connections.
+     * 
+     * This method should:
+     * - Close all active connections gracefully
+     * - Clean up any resources
+     * - Cancel any background jobs
+     * - Be idempotent (safe to call multiple times)
+     */
+    suspend fun stop()
+    
+    /**
+     * Checks if the connection manager is currently running.
+     * 
+     * @return true if the manager is accepting connections, false otherwise
+     */
+    fun isRunning(): Boolean
+    
+    /**
+     * Gets the port number the server is listening on.
+     * 
+     * @return the configured port number
+     */
+    fun getPort(): Int
+    
+    /**
+     * Checks if SSL/TLS is supported by this connection manager.
+     * 
+     * @return true if SSL is enabled, false otherwise
+     */
+    fun supportsSSL(): Boolean
+    
+    /**
+     * Sets the protocol handler for processing messages.
+     * 
+     * The protocol handler is responsible for:
+     * - Parsing incoming messages
+     * - Routing to appropriate handlers
+     * - Generating responses
+     * - Managing protocol-specific concerns
+     * 
+     * @param handler the protocol handler to use for message processing
+     */
+    fun setProtocolHandler(handler: JsonRpcProtocolHandler)
+    
+    /**
+     * Gets all currently active connections.
+     * 
+     * @return a list of active connection states
+     */
+    suspend fun getActiveConnections(): List<WebSocketConnection>
+    
+    /**
+     * Gets a specific connection by its unique identifier.
+     * 
+     * @param id the connection identifier
+     * @return the connection if found, null otherwise
+     */
+    suspend fun getConnectionById(id: String): WebSocketConnection?
+    
+    /**
+     * Gets the maximum message queue size for connections.
+     * 
+     * @return the configured message queue size
+     */
+    fun getMessageQueueSize(): Int
+    
+    /**
+     * Sets the logger for connection manager operations.
+     * 
+     * @param logger the logger implementation to use
+     */
+    fun setLogger(logger: WebSocketLogger)
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/DefaultConnectionFactory.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/DefaultConnectionFactory.kt
@@ -1,0 +1,50 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import io.ktor.websocket.DefaultWebSocketSession
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Default implementation of the ConnectionFactory interface.
+ * 
+ * Creates WebSocket connections with UUID-based identifiers and
+ * proper initialization of tracking metadata.
+ * 
+ * ## Design Choices
+ * - UUID v4 for guaranteed uniqueness
+ * - Atomic references for thread-safe activity tracking
+ * - Immutable connection metadata
+ * 
+ * ## Future Enhancements
+ * Could be extended to support:
+ * - Custom ID generation strategies
+ * - Connection pooling
+ * - Metadata enrichment
+ * - Connection recycling
+ */
+class DefaultConnectionFactory : ConnectionFactory {
+    
+    override fun createConnection(session: DefaultWebSocketSession): ActiveWebSocketSession {
+        val now = Instant.now()
+        return ActiveWebSocketSession(
+            id = generateConnectionId(),
+            session = session,
+            connectedAt = now,
+            lastActivity = AtomicReference(now)
+        )
+    }
+    
+    override fun generateConnectionId(): String {
+        return UUID.randomUUID().toString()
+    }
+    
+    override fun isValidConnectionId(connectionId: String): Boolean {
+        return try {
+            UUID.fromString(connectionId)
+            true
+        } catch (e: IllegalArgumentException) {
+            false
+        }
+    }
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/DefaultHeartbeatManager.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/DefaultHeartbeatManager.kt
@@ -1,0 +1,128 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import io.ktor.websocket.*
+import kotlinx.coroutines.*
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Default implementation of the HeartbeatManager interface.
+ * 
+ * Manages WebSocket ping-pong heartbeats and connection timeouts using
+ * coroutines for non-blocking operation.
+ * 
+ * ## Implementation Strategy
+ * - Uses a supervisor job for fault isolation
+ * - Periodic coroutine for heartbeat checks
+ * - Thread-safe activity tracking with ConcurrentHashMap
+ * - Graceful handling of connection failures
+ * 
+ * ## Performance Considerations
+ * - Heartbeat operations run on IO dispatcher
+ * - Batch processing of connections to minimize overhead
+ * - Non-blocking send operations
+ */
+class DefaultHeartbeatManager(
+    private val config: WebSocketServerConfig,
+    private val logger: WebSocketLogger,
+    private val connectionProvider: () -> Collection<ActiveWebSocketSession>
+) : HeartbeatManager {
+    
+    private val isRunning = AtomicBoolean(false)
+    private var heartbeatJob: Job? = null
+    private val supervisorJob = SupervisorJob()
+    private val coroutineScope = CoroutineScope(Dispatchers.IO + supervisorJob)
+    private val lastActivityMap = ConcurrentHashMap<String, Instant>()
+    
+    override suspend fun start() {
+        if (isRunning.compareAndSet(false, true)) {
+            if (config.heartbeatInterval > Duration.ZERO) {
+                startHeartbeatLoop()
+                logger.logInfo("Heartbeat manager started with interval: ${config.heartbeatInterval}")
+            }
+        }
+    }
+    
+    override suspend fun stop() {
+        if (isRunning.compareAndSet(true, false)) {
+            heartbeatJob?.cancel()
+            heartbeatJob = null
+            supervisorJob.cancel()
+            lastActivityMap.clear()
+            logger.logInfo("Heartbeat manager stopped")
+        }
+    }
+    
+    override fun isRunning(): Boolean = isRunning.get()
+    
+    override fun getHeartbeatInterval(): Duration = config.heartbeatInterval
+    
+    override fun getConnectionTimeout(): Duration = config.connectionTimeout
+    
+    override fun recordActivity(connectionId: String) {
+        lastActivityMap[connectionId] = Instant.now()
+    }
+    
+    override fun isConnectionTimedOut(connectionId: String): Boolean {
+        val lastActivity = lastActivityMap[connectionId] ?: return true
+        val timeSinceActivity = Duration.between(lastActivity, Instant.now())
+        return timeSinceActivity > config.connectionTimeout
+    }
+    
+    private fun startHeartbeatLoop() {
+        heartbeatJob = coroutineScope.launch {
+            while (isActive && isRunning.get()) {
+                delay(config.heartbeatInterval.toMillis())
+                checkConnections()
+            }
+        }
+    }
+    
+    private suspend fun checkConnections() {
+        val connections = connectionProvider()
+        
+        connections.forEach { session ->
+            try {
+                sendPingAndCheckTimeout(session)
+            } catch (e: Exception) {
+                logger.logError("Error during heartbeat for ${session.id}", e)
+            }
+        }
+        
+        // Clean up inactive connections from tracking
+        val activeIds = connections.map { it.id }.toSet()
+        lastActivityMap.keys.removeIf { it !in activeIds }
+    }
+    
+    private suspend fun sendPingAndCheckTimeout(session: ActiveWebSocketSession) {
+        try {
+            // Send ping frame
+            session.session.send(Frame.Ping(ByteArray(0)))
+            logger.logDebug("Sent ping to ${session.id}")
+            
+            // Record this as activity (we're actively pinging)
+            recordActivity(session.id)
+            
+            // Check for timeout based on session's last activity
+            val timeSinceActivity = Duration.between(session.lastActivity.get(), Instant.now())
+            if (timeSinceActivity > config.connectionTimeout) {
+                logger.logInfo("Connection timed out: ${session.id}")
+                closeConnection(session)
+            }
+        } catch (e: Exception) {
+            logger.logError("Failed to send ping to ${session.id}", e)
+            // Connection might be dead, try to close it
+            closeConnection(session)
+        }
+    }
+    
+    private suspend fun closeConnection(session: ActiveWebSocketSession) {
+        try {
+            session.session.close(CloseReason(CloseReason.Codes.GOING_AWAY, "Connection timeout"))
+        } catch (e: Exception) {
+            logger.logDebug("Error closing timed-out connection ${session.id}: ${e.message}")
+        }
+    }
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/DefaultMessageHandler.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/DefaultMessageHandler.kt
@@ -1,0 +1,135 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcProtocolHandler
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcRequest
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcResponse
+import io.spiralhouse.cycletime.mcp.protocol.ProtocolHandler
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Default implementation of the MessageHandler interface.
+ * 
+ * Handles JSON-RPC message processing and routing to registered method handlers.
+ * This implementation focuses on JSON-RPC protocol but can be extended for
+ * other message formats.
+ * 
+ * ## Thread Safety
+ * - Uses ConcurrentHashMap for thread-safe method handler storage
+ * - All public methods are safe for concurrent access
+ * 
+ * ## Error Handling Strategy
+ * - Parse errors return JSON-RPC error response (-32700)
+ * - Method not found returns error response (-32601)
+ * - Internal errors return error response (-32603)
+ * - Binary messages return error response (-32600)
+ */
+class DefaultMessageHandler : MessageHandler {
+    
+    private var protocolHandler: JsonRpcProtocolHandler? = null
+    private val methodHandlers = ConcurrentHashMap<String, (JsonRpcRequest) -> JsonRpcResponse>()
+    
+    // Constructor for direct configuration
+    constructor(
+        config: WebSocketServerConfig,
+        logger: WebSocketLogger
+    ) {
+        this.config = config
+        this.logger = logger
+    }
+    
+    private var config: WebSocketServerConfig = WebSocketServerConfig()
+    private var logger: WebSocketLogger = DefaultWebSocketLogger()
+    
+    /**
+     * Sets the protocol handler for JSON-RPC processing.
+     */
+    override fun setProtocolHandler(handler: JsonRpcProtocolHandler) {
+        this.protocolHandler = handler
+    }
+    
+    override suspend fun handleTextMessage(connectionId: String, message: String): String? {
+        if (message.length > config.maxMessageSize) {
+            logger.logError("Message too large from $connectionId: ${message.length} bytes", null)
+            return createErrorResponse(null, -32600, "Message too large")
+        }
+        
+        val handler = protocolHandler ?: run {
+            logger.logError("No protocol handler set", null)
+            return createErrorResponse(null, -32603, "Server not configured")
+        }
+        
+        return try {
+            val request = parseRequest(handler, message, connectionId)
+            processRequest(handler, request)
+        } catch (e: Exception) {
+            logger.logError("Error processing message from $connectionId", e)
+            createErrorResponse(null, -32603, "Internal server error")
+        }
+    }
+    
+    override suspend fun handleBinaryMessage(connectionId: String, data: ByteArray): ByteArray? {
+        logger.logError("Binary frames not supported", null)
+        // Return error as text since we don't support binary
+        return null
+    }
+    
+    override fun registerMethodHandler(method: String, handler: (JsonRpcRequest) -> JsonRpcResponse) {
+        methodHandlers[method] = handler
+        logger.logDebug("Registered handler for method: $method")
+    }
+    
+    override fun hasMethodHandler(method: String): Boolean = methodHandlers.containsKey(method)
+    
+    override fun getMaxMessageSize(): Int = config.maxMessageSize
+    
+    private fun parseRequest(handler: JsonRpcProtocolHandler, message: String, connectionId: String): JsonRpcRequest {
+        return try {
+            handler.parseRequest(message)
+        } catch (e: Exception) {
+            logger.logError("Failed to parse JSON-RPC request from $connectionId", e)
+            throw e
+        }
+    }
+    
+    private fun processRequest(handler: JsonRpcProtocolHandler, request: JsonRpcRequest): String? {
+        // Check if it's a notification (no response needed)
+        if (handler.isNotification(request)) {
+            handler.handleNotification(request)
+            return null
+        }
+        
+        val response = findAndExecuteHandler(handler, request)
+        return handler.serializeResponse(response)
+    }
+    
+    private fun findAndExecuteHandler(handler: JsonRpcProtocolHandler, request: JsonRpcRequest): JsonRpcResponse {
+        // Try registered method handlers first
+        val methodHandler = methodHandlers[request.method]
+        if (methodHandler != null) {
+            return try {
+                methodHandler(request)
+            } catch (e: Exception) {
+                handler.createErrorResponse(
+                    request.id,
+                    -32603,
+                    "Method execution failed: ${e.message}",
+                    null
+                )
+            }
+        }
+        
+        // Method not found
+        return handler.createErrorResponse(
+            request.id,
+            -32601,
+            "Method not found: ${request.method}",
+            null
+        )
+    }
+    
+    private fun createErrorResponse(id: Any?, code: Int, message: String): String? {
+        val handler = protocolHandler ?: return null
+        val response = handler.createErrorResponse(id, code, message, null)
+        return handler.serializeResponse(response)
+    }
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/HeartbeatManager.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/HeartbeatManager.kt
@@ -1,0 +1,83 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import java.time.Duration
+
+/**
+ * Interface for managing connection heartbeats and health checks.
+ * 
+ * This abstraction handles the ping-pong mechanism for WebSocket connections
+ * and monitors connection health to detect and clean up stale connections.
+ * 
+ * ## Design Philosophy
+ * - Proactive connection health monitoring
+ * - Configurable timeout and interval settings
+ * - Automatic cleanup of dead connections
+ * - Non-blocking asynchronous operations
+ * 
+ * ## Implementation Notes
+ * - Must be thread-safe for concurrent connection monitoring
+ * - Should handle failures gracefully without affecting other connections
+ * - Heartbeat timing should be configurable per deployment
+ */
+interface HeartbeatManager {
+    
+    /**
+     * Starts the heartbeat monitoring process.
+     * 
+     * This method should:
+     * - Begin periodic health checks
+     * - Send ping frames at configured intervals
+     * - Monitor for pong responses
+     * - Clean up timed-out connections
+     */
+    suspend fun start()
+    
+    /**
+     * Stops the heartbeat monitoring process.
+     * 
+     * This method should:
+     * - Cancel any running heartbeat jobs
+     * - Clean up resources
+     * - Be idempotent
+     */
+    suspend fun stop()
+    
+    /**
+     * Checks if heartbeat monitoring is currently active.
+     * 
+     * @return true if heartbeat monitoring is running
+     */
+    fun isRunning(): Boolean
+    
+    /**
+     * Gets the configured heartbeat interval.
+     * 
+     * @return the duration between heartbeat pings
+     */
+    fun getHeartbeatInterval(): Duration
+    
+    /**
+     * Gets the configured connection timeout.
+     * 
+     * @return the duration after which idle connections are closed
+     */
+    fun getConnectionTimeout(): Duration
+    
+    /**
+     * Records activity for a specific connection.
+     * 
+     * This method updates the last activity timestamp for a connection,
+     * preventing it from timing out.
+     * 
+     * @param connectionId the identifier of the active connection
+     */
+    fun recordActivity(connectionId: String)
+    
+    /**
+     * Checks if a connection has timed out.
+     * 
+     * @param connectionId the identifier of the connection to check
+     * @return true if the connection has exceeded the timeout threshold
+     */
+    fun isConnectionTimedOut(connectionId: String): Boolean
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/MessageHandler.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/MessageHandler.kt
@@ -1,0 +1,68 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcRequest
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcResponse
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcProtocolHandler
+
+/**
+ * Interface for handling incoming messages in the connection manager.
+ * 
+ * This abstraction allows for different message handling strategies
+ * and supports the Strategy pattern for processing various message types.
+ * 
+ * ## Design Rationale
+ * - Separation of message handling from connection management
+ * - Support for multiple message formats (JSON-RPC, binary protocols, etc.)
+ * - Extensible handler registration mechanism
+ * - Clear error handling boundaries
+ */
+interface MessageHandler {
+    
+    /**
+     * Processes a text-based message from a connection.
+     * 
+     * @param connectionId the identifier of the connection that sent the message
+     * @param message the text message to process
+     * @return the response to send back, or null for notifications
+     */
+    suspend fun handleTextMessage(connectionId: String, message: String): String?
+    
+    /**
+     * Processes a binary message from a connection.
+     * 
+     * @param connectionId the identifier of the connection that sent the message
+     * @param data the binary data to process
+     * @return the response to send back, or null if no response needed
+     */
+    suspend fun handleBinaryMessage(connectionId: String, data: ByteArray): ByteArray?
+    
+    /**
+     * Registers a method-specific handler for JSON-RPC requests.
+     * 
+     * @param method the JSON-RPC method name to handle
+     * @param handler the function to process requests for this method
+     */
+    fun registerMethodHandler(method: String, handler: (JsonRpcRequest) -> JsonRpcResponse)
+    
+    /**
+     * Checks if a specific JSON-RPC method is registered.
+     * 
+     * @param method the method name to check
+     * @return true if a handler is registered for this method
+     */
+    fun hasMethodHandler(method: String): Boolean
+    
+    /**
+     * Gets the maximum allowed message size in bytes.
+     * 
+     * @return the maximum message size
+     */
+    fun getMaxMessageSize(): Int
+    
+    /**
+     * Sets the protocol handler for JSON-RPC processing.
+     * 
+     * @param handler the protocol handler to use
+     */
+    fun setProtocolHandler(handler: JsonRpcProtocolHandler)
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketConnection.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketConnection.kt
@@ -1,0 +1,47 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import io.ktor.websocket.*
+import kotlinx.coroutines.channels.SendChannel
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Represents a WebSocket connection state.
+ * 
+ * @property id Unique identifier for this connection
+ * @property isActive Whether the connection is currently active
+ * @property connectedAt When the connection was established
+ * @property lastActivity When the connection was last active
+ */
+data class WebSocketConnection(
+    val id: String,
+    val isActive: Boolean,
+    val connectedAt: Instant,
+    val lastActivity: Instant
+)
+
+/**
+ * Wrapper for active WebSocket sessions with state tracking.
+ * 
+ * This class is used internally by the connection manager to track
+ * WebSocket sessions with additional metadata.
+ */
+data class ActiveWebSocketSession(
+    val id: String,
+    val session: DefaultWebSocketSession,
+    val connectedAt: Instant,
+    val lastActivity: AtomicReference<Instant>
+) {
+    fun toConnection(): WebSocketConnection {
+        return WebSocketConnection(
+            id = id,
+            isActive = !session.closeReason.isCompleted,
+            connectedAt = connectedAt,
+            lastActivity = lastActivity.get()
+        )
+    }
+    
+    fun updateActivity() {
+        lastActivity.set(Instant.now())
+    }
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketConnectionManager.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketConnectionManager.kt
@@ -1,0 +1,451 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.cio.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.websocket.*
+import io.ktor.websocket.*
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcProtocolHandler
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcRequest
+import io.spiralhouse.cycletime.mcp.protocol.JsonRpcResponse
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.toKotlinDuration
+
+/**
+ * WebSocket-specific implementation of ConnectionManager.
+ * 
+ * Manages WebSocket server lifecycle, connections, and message routing through
+ * a modular architecture with separated concerns.
+ * 
+ * ## Architecture
+ * This class orchestrates several components:
+ * - Server lifecycle management (start/stop)
+ * - Connection tracking and state management
+ * - Message routing through MessageHandler
+ * - Heartbeat monitoring through HeartbeatManager
+ * - Event notifications through ConnectionEventListener
+ * 
+ * ## Thread Safety
+ * - All public methods are thread-safe
+ * - Uses mutex for connection collection modifications
+ * - Atomic operations for server state
+ * 
+ * ## Resource Management
+ * - Proper cleanup on shutdown
+ * - Graceful connection closure
+ * - Coroutine scope management
+ * 
+ * @property config Configuration for the WebSocket server
+ */
+class WebSocketConnectionManager(
+    private val config: WebSocketServerConfig = WebSocketServerConfig()
+) : ConnectionManager {
+    // Core components
+    private var server: EmbeddedServer<*, *>? = null
+    private val isServerRunning = AtomicBoolean(false)
+    private val connections = ConcurrentHashMap<String, ActiveWebSocketSession>()
+    private val connectionsMutex = Mutex()
+    
+    // Delegated responsibilities
+    private var logger: WebSocketLogger = DefaultWebSocketLogger()
+    private var messageHandler: MessageHandler = DefaultMessageHandler(config, logger)
+    private val connectionFactory = DefaultConnectionFactory()
+    private val heartbeatManager = DefaultHeartbeatManager(
+        config, 
+        logger,
+        connectionProvider = { connections.values }
+    )
+    
+    // Event handling
+    private val eventListeners = mutableListOf<ConnectionEventListener>()
+    
+    // Protocol handling
+    private var protocolHandler: JsonRpcProtocolHandler? = null
+    
+    // Coroutine management
+    private val supervisorJob = SupervisorJob()
+    
+    /**
+     * Starts the WebSocket server.
+     * 
+     * This method:
+     * 1. Configures the Ktor server with WebSocket support
+     * 2. Starts listening on the configured port
+     * 3. Initializes heartbeat monitoring if enabled
+     * 4. Sets up routing for WebSocket connections
+     * 
+     * @throws WebSocketServerException if the server fails to start
+     */
+    override suspend fun start() {
+        if (isServerRunning.get()) {
+            logger.logInfo("Server is already running on port ${config.port}")
+            return
+        }
+        
+        try {
+            server = embeddedServer(CIO, port = config.port, host = "0.0.0.0") {
+                install(WebSockets) {
+                    pingPeriod = config.heartbeatInterval.toKotlinDuration()
+                    timeout = config.connectionTimeout.toKotlinDuration()
+                    maxFrameSize = config.maxMessageSize.toLong()
+                    masking = false
+                }
+                
+                routing {
+                    // Handle non-WebSocket requests with proper error
+                    get("/") {
+                        call.respondText(
+                            "WebSocket endpoint. Use ws:// or wss:// protocol.",
+                            status = HttpStatusCode.BadRequest
+                        )
+                    }
+                    
+                    webSocket("/") {
+                        handleConnection(this)
+                    }
+                }
+            }
+            
+            server?.start(wait = false)
+            isServerRunning.set(true)
+            logger.logInfo("WebSocket server started on port ${config.port}")
+            
+            // Start heartbeat manager
+            heartbeatManager.start()
+            
+        } catch (e: Exception) {
+            throw WebSocketServerException("Failed to start WebSocket server on port ${config.port}", e)
+        }
+    }
+    
+    /**
+     * Stops the WebSocket server gracefully.
+     * 
+     * This method:
+     * 1. Stops heartbeat monitoring
+     * 2. Closes all active connections
+     * 3. Shuts down the server
+     * 4. Cleans up resources
+     */
+    override suspend fun stop() {
+        if (!isServerRunning.get()) {
+            return
+        }
+        
+        logger.logInfo("Stopping WebSocket server...")
+        
+        // Stop heartbeat manager
+        heartbeatManager.stop()
+        
+        // Close all connections
+        closeAllConnections()
+        
+        // Stop server
+        server?.stop(1000, 2000)
+        server = null
+        isServerRunning.set(false)
+        
+        // Cancel coroutine scope
+        supervisorJob.cancel()
+        
+        logger.logInfo("WebSocket server stopped")
+    }
+    
+    override fun isRunning(): Boolean = isServerRunning.get()
+    
+    override fun getPort(): Int = config.port
+    
+    override fun supportsSSL(): Boolean = config.enableSsl
+    
+    override fun setProtocolHandler(handler: JsonRpcProtocolHandler) {
+        this.protocolHandler = handler
+        messageHandler.setProtocolHandler(handler)
+    }
+    
+    override suspend fun getActiveConnections(): List<WebSocketConnection> {
+        return connectionsMutex.withLock {
+            connections.values.map { it.toConnection() }
+        }
+    }
+    
+    override suspend fun getConnectionById(id: String): WebSocketConnection? {
+        return connectionsMutex.withLock {
+            connections[id]?.toConnection()
+        }
+    }
+    
+    /**
+     * Registers a method handler for JSON-RPC requests.
+     * 
+     * @param method the JSON-RPC method name
+     * @param handler the handler function for this method
+     */
+    fun registerMethodHandler(method: String, handler: (JsonRpcRequest) -> JsonRpcResponse) {
+        messageHandler.registerMethodHandler(method, handler)
+    }
+    
+    override fun getMessageQueueSize(): Int = config.messageQueueSize
+    
+    override fun setLogger(logger: WebSocketLogger) {
+        this.logger = logger
+    }
+    
+    /**
+     * Adds an event listener for connection events.
+     * 
+     * @param listener the event listener to add
+     */
+    fun addEventListener(listener: ConnectionEventListener) {
+        eventListeners.add(listener)
+    }
+    
+    /**
+     * Removes an event listener.
+     * 
+     * @param listener the event listener to remove
+     */
+    fun removeEventListener(listener: ConnectionEventListener) {
+        eventListeners.remove(listener)
+    }
+    
+    /**
+     * Sets the message handler for processing incoming messages.
+     * 
+     * @param handler the message handler to set
+     */
+    fun setMessageHandler(handler: MessageHandler) {
+        this.messageHandler = handler
+    }
+    
+    /**
+     * Gets the current number of active connections.
+     * 
+     * @return the number of active connections
+     */
+    fun getActiveConnectionCount(): Int {
+        return connections.size
+    }
+    
+    // Private implementation methods
+    
+    /**
+     * Handles a new WebSocket connection.
+     * 
+     * @param session the WebSocket session to handle
+     */
+    private suspend fun handleConnection(session: DefaultWebSocketSession) {
+        val activeSession = connectionFactory.createConnection(session)
+        val connectionId = activeSession.id
+        
+        // Add to connections
+        connectionsMutex.withLock {
+            connections[connectionId] = activeSession
+        }
+        
+        logger.logInfo("New WebSocket connection: $connectionId")
+        
+        // Notify listeners
+        notifyConnectionEstablished(activeSession.toConnection())
+        
+        try {
+            // Handle incoming messages
+            for (frame in session.incoming) {
+                when (frame) {
+                    is Frame.Text -> {
+                        handleTextFrame(activeSession, frame.readText())
+                    }
+                    is Frame.Binary -> {
+                        handleBinaryFrame(activeSession, frame.data)
+                    }
+                    is Frame.Pong -> {
+                        handlePongFrame(activeSession)
+                    }
+                    is Frame.Ping -> {
+                        handlePingFrame(activeSession, frame)
+                    }
+                    is Frame.Close -> {
+                        logger.logInfo("Connection closed by client: $connectionId")
+                        notifyConnectionClosed(connectionId, "Client initiated close")
+                        break
+                    }
+                }
+            }
+        } catch (e: ClosedReceiveChannelException) {
+            logger.logInfo("Connection closed: $connectionId")
+            notifyConnectionClosed(connectionId, "Channel closed")
+        } catch (e: Exception) {
+            logger.logError("Error in connection $connectionId", e)
+            notifyConnectionError(connectionId, e)
+        } finally {
+            // Remove from connections
+            connectionsMutex.withLock {
+                connections.remove(connectionId)
+            }
+            logger.logInfo("Removed connection: $connectionId")
+            
+            // Ensure listeners are notified if not already done
+            if (!activeSession.session.closeReason.isCompleted) {
+                notifyConnectionClosed(connectionId, "Unexpected closure")
+            }
+        }
+    }
+    
+    /**
+     * Handles incoming text frames.
+     */
+    private suspend fun handleTextFrame(session: ActiveWebSocketSession, text: String) {
+        session.updateActivity()
+        heartbeatManager.recordActivity(session.id)
+        notifyMessageReceived(session.id, text.length)
+        
+        val response = messageHandler.handleTextMessage(session.id, text)
+        if (response != null) {
+            session.session.send(Frame.Text(response))
+            notifyMessageSent(session.id, response.length)
+            logger.logDebug("Sent response to ${session.id}")
+        }
+    }
+    
+    /**
+     * Handles incoming binary frames.
+     */
+    private suspend fun handleBinaryFrame(session: ActiveWebSocketSession, data: ByteArray) {
+        session.updateActivity()
+        heartbeatManager.recordActivity(session.id)
+        notifyMessageReceived(session.id, data.size)
+        
+        val response = messageHandler.handleBinaryMessage(session.id, data)
+        if (response != null) {
+            // We don't support binary responses, but keeping the interface
+            logger.logError("Binary response not supported", null)
+        } else {
+            // Send error as text
+            val handler = protocolHandler
+            if (handler != null) {
+                val errorResponse = handler.createErrorResponse(
+                    null,
+                    -32600,
+                    "Binary frames not supported",
+                    null
+                )
+                session.session.send(Frame.Text(handler.serializeResponse(errorResponse)))
+            }
+        }
+    }
+    
+    /**
+     * Handles pong frames (heartbeat response).
+     */
+    private fun handlePongFrame(session: ActiveWebSocketSession) {
+        session.updateActivity()
+        heartbeatManager.recordActivity(session.id)
+        logger.logDebug("Received pong from ${session.id}")
+    }
+    
+    /**
+     * Handles ping frames (heartbeat request).
+     */
+    private suspend fun handlePingFrame(session: ActiveWebSocketSession, frame: Frame.Ping) {
+        session.updateActivity()
+        heartbeatManager.recordActivity(session.id)
+        session.session.send(Frame.Pong(frame.buffer))
+        logger.logDebug("Replied to ping from ${session.id}")
+    }
+    
+    /**
+     * Event notification helpers
+     */
+    private fun notifyConnectionEstablished(connection: WebSocketConnection) {
+        eventListeners.forEach { listener ->
+            try {
+                listener.onConnectionEstablished(connection)
+            } catch (e: Exception) {
+                logger.logError("Error notifying listener of connection established", e)
+            }
+        }
+    }
+    
+    private fun notifyConnectionClosed(connectionId: String, reason: String?) {
+        eventListeners.forEach { listener ->
+            try {
+                listener.onConnectionClosed(connectionId, reason)
+            } catch (e: Exception) {
+                logger.logError("Error notifying listener of connection closed", e)
+            }
+        }
+    }
+    
+    private fun notifyMessageReceived(connectionId: String, messageSize: Int) {
+        eventListeners.forEach { listener ->
+            try {
+                listener.onMessageReceived(connectionId, messageSize)
+            } catch (e: Exception) {
+                logger.logError("Error notifying listener of message received", e)
+            }
+        }
+    }
+    
+    private fun notifyMessageSent(connectionId: String, messageSize: Int) {
+        eventListeners.forEach { listener ->
+            try {
+                listener.onMessageSent(connectionId, messageSize)
+            } catch (e: Exception) {
+                logger.logError("Error notifying listener of message sent", e)
+            }
+        }
+    }
+    
+    private fun notifyConnectionError(connectionId: String, error: Throwable) {
+        eventListeners.forEach { listener ->
+            try {
+                listener.onConnectionError(connectionId, error)
+            } catch (e: Exception) {
+                logger.logError("Error notifying listener of connection error", e)
+            }
+        }
+    }
+    
+    // Note: Connection timeout notification is handled by HeartbeatManager
+    // This method is kept for future use when implementing timeout notifications
+    @Suppress("UnusedPrivateMember")
+    private fun notifyConnectionTimeout(connectionId: String) {
+        eventListeners.forEach { listener ->
+            try {
+                listener.onConnectionTimeout(connectionId)
+            } catch (e: Exception) {
+                logger.logError("Error notifying listener of connection timeout", e)
+            }
+        }
+    }
+    
+    /**
+     * Closes all active connections during shutdown.
+     */
+    private suspend fun closeAllConnections() {
+        val connectionsToClose = connectionsMutex.withLock {
+            connections.values.toList()
+        }
+        
+        connectionsToClose.forEach { session ->
+            try {
+                session.session.close(CloseReason(CloseReason.Codes.GOING_AWAY, "Server shutting down"))
+                notifyConnectionClosed(session.id, "Server shutdown")
+            } catch (e: Exception) {
+                logger.logError("Error closing connection ${session.id}", e)
+            }
+        }
+        
+        connectionsMutex.withLock {
+            connections.clear()
+        }
+    }
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketLogger.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketLogger.kt
@@ -1,0 +1,28 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+/**
+ * Logger interface for WebSocket operations.
+ */
+interface WebSocketLogger {
+    fun logError(message: String, throwable: Throwable?)
+    fun logInfo(message: String)
+    fun logDebug(message: String)
+}
+
+/**
+ * Default implementation that logs to standard output.
+ */
+class DefaultWebSocketLogger : WebSocketLogger {
+    override fun logError(message: String, throwable: Throwable?) {
+        println("[ERROR] WebSocket: $message")
+        throwable?.printStackTrace()
+    }
+    
+    override fun logInfo(message: String) {
+        println("[INFO] WebSocket: $message")
+    }
+    
+    override fun logDebug(message: String) {
+        println("[DEBUG] WebSocket: $message")
+    }
+}

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketServerConfig.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketServerConfig.kt
@@ -1,0 +1,40 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+import java.time.Duration
+
+/**
+ * Configuration for WebSocket server.
+ * 
+ * @property port The port to listen on (default: 3000)
+ * @property host The host to bind to (default: "0.0.0.0")
+ * @property path The WebSocket path (default: "/ws")
+ * @property enableSsl Whether to enable SSL/TLS (default: false)
+ * @property sslKeyStore Path to the SSL keystore file
+ * @property sslKeyStorePassword Password for the SSL keystore
+ * @property connectionTimeout How long to keep idle connections alive
+ * @property heartbeatInterval How often to send ping frames
+ * @property pongTimeout How long to wait for pong responses
+ * @property maxMessageSize Maximum message size in bytes
+ * @property messageQueueSize Size of the message queue per connection
+ * @property pingPeriod Ping period in milliseconds
+ * @property timeout Connection timeout in milliseconds
+ * @property maxFrameSize Maximum frame size in bytes
+ * @property masking Whether to enable masking
+ */
+data class WebSocketServerConfig(
+    val port: Int = 3000,
+    val host: String = "0.0.0.0",
+    val path: String = "/ws",
+    val enableSsl: Boolean = false,
+    val sslKeyStore: String? = null,
+    val sslKeyStorePassword: String? = null,
+    val connectionTimeout: Duration = Duration.ofMinutes(30),
+    val heartbeatInterval: Duration = Duration.ofSeconds(30),
+    val pongTimeout: Duration = Duration.ofSeconds(10),
+    val maxMessageSize: Int = 1024 * 1024, // 1MB
+    val messageQueueSize: Int = 1000,
+    val pingPeriod: Long = 30000L,
+    val timeout: Long = 60000L,
+    val maxFrameSize: Long = 1024 * 1024L,
+    val masking: Boolean = false
+)

--- a/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketServerException.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/mcp/websocket/WebSocketServerException.kt
@@ -1,0 +1,6 @@
+package io.spiralhouse.cycletime.mcp.websocket
+
+/**
+ * Exception thrown by WebSocket server operations.
+ */
+class WebSocketServerException(message: String, cause: Throwable? = null) : Exception(message, cause)


### PR DESCRIPTION
## Summary

Extracting WebSocket infrastructure as Phase 3 of splitting the MCP mega-PR (#57) into reviewable chunks.

This PR adds the WebSocket layer that operates on top of the JSON-RPC protocol merged in PR #59.

## What's Included

- **WebSocket Components** (~1680 lines total, 16 files)
  - Connection management and pooling (`MCPConnectionManager`)
  - WebSocket handlers and configuration
  - Connection lifecycle management
  - WebSocket interfaces and implementations
  - Performance optimizations

## Context

Part of [SPI-588](https://linear.app/spiral-house/issue/SPI-588): Split MCP Mega-PR into Reviewable Chunks

**Phase 3 of 9**: WebSocket Infrastructure

## Dependencies

- Requires PR #59 (JSON-RPC Protocol Layer) - Already merged ✅

## Test Coverage

- Unit tests for WebSocket functionality will be re-enabled in Phase 9 (SPI-587)
- Integration tests will be added when all components are merged

## Line Count

- 1679 lines added (slightly over target of 1200 but within acceptable range)
- Clean separation of WebSocket concerns from MCP method handlers

## Next Steps

After this PR is merged, Phase 4 will add the Tool framework.