### PR TITLE
fix(ci): force full CI pipeline for Dependabot PRs for security validation (SPI-628)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -104,7 +104,12 @@ jobs:
         id: changes
         run: |
           echo "🔍 Checking for relevant changes..."
-          if git diff --name-only HEAD~1 HEAD | grep -E '\.(kt|kts|java|gradle)$|src/|build\.gradle|settings\.gradle|gradle\.properties'; then
+
+          # Always run tests for Dependabot PRs (security validation required)
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "🤖 Dependabot PR detected - running full security validation pipeline"
+            echo "run_tests=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only HEAD~1 HEAD | grep -E '\.(kt|kts|java|gradle)$|src/|build\.gradle|settings\.gradle|gradle\.properties|gradle/.*\.toml|gradle/'; then
             echo "✅ Code changes detected - will run full pipeline"
             echo "run_tests=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
- Fix Dependabot PRs not triggering full CI pipeline
- Ensure security validation for all dependency updates
- Resolve issue where critical test suites were being skipped

## Problem
Dependabot PR #87 (HikariCP upgrade) was only running:
- ✅ Version calculation, Code Quality, Security Scan
- ❌ **SKIPPED**: Compile, Unit Tests, Integration Tests, System Tests, Build

## Root Cause
The change detection logic in `.github/workflows/cicd.yml` wasn't properly detecting Gradle dependency file changes, causing `run_tests=false` for Dependabot PRs.

## Solution
1. **Added explicit Dependabot detection**: `github.actor == "dependabot[bot]"` 
2. **Force full CI for security validation**: All Dependabot PRs now run complete test suite
3. **Enhanced change detection**: Better support for `gradle/libs.versions.toml` and Gradle files

## Security Impact
- ✅ All dependency updates now get proper validation
- ✅ Unit, integration, and system tests verify compatibility  
- ✅ Build process validates deployability
- ✅ Prevents vulnerable dependencies from reaching production

## Test Plan
- [x] Workflow syntax validated with `gh workflow view`
- [ ] Verify PR #87 triggers full CI after this is merged
- [ ] Confirm future Dependabot PRs run complete validation pipeline

## Files Changed
- `.github/workflows/cicd.yml` - Enhanced change detection logic

🤖 Generated with [Claude Code](https://claude.ai/code)