### PR TITLE
docs: add development status alert to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CycleTime - Context Management for Claude Code
 
-> [!ALERT]
+> [!CAUTION]
 > **Development Status**: CycleTime is currently under active development as we work towards our MVP release. While core functionality is operational, features and APIs may change. For detailed information about current capabilities and roadmap, see our [MVP Capability Summary](docs/MVP_CAPABILITY_SUMMARY.md).
 
 *Community Edition*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # CycleTime - Context Management for Claude Code
 
+> [!NOTE]
+> **Development Status**: CycleTime is currently under active development as we work towards our MVP release. While core functionality is operational, features and APIs may change. For detailed information about current capabilities and roadmap, see our [MVP Capability Summary](docs/MVP_CAPABILITY_SUMMARY.md).
+
 *Community Edition*
 
 [![Build Status](https://github.com/spiralhouse/cycletime/actions/workflows/cicd.yml/badge.svg)](https://github.com/spiralhouse/cycletime/actions/workflows/cicd.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CycleTime - Context Management for Claude Code
 
-> [!NOTE]
+> [!ALERT]
 > **Development Status**: CycleTime is currently under active development as we work towards our MVP release. While core functionality is operational, features and APIs may change. For detailed information about current capabilities and roadmap, see our [MVP Capability Summary](docs/MVP_CAPABILITY_SUMMARY.md).
 
 *Community Edition*


### PR DESCRIPTION
Add GitHub-flavored markdown alert to inform users that CycleTime is under active development towards MVP release. Alert includes link to MVP Capability Summary for detailed status and roadmap information.

🤖 Generated with [Claude Code](https://claude.ai/code)