### PR TITLE
docs: update all documentation from WebSocket to SSE transport (SPI-665)

### DIFF
--- a/.claude/shared/testing-standards.md
+++ b/.claude/shared/testing-standards.md
@@ -289,7 +289,7 @@ src/test/kotlin/io/spiralhouse/cycletime/
 
 **Integration Tests**:
 - `mcp.integration.*` - MCP server integration
-- `mcp.server.*` - Server infrastructure, WebSocket connections
+- `mcp.server.*` - Server infrastructure, SSE connections
 - Database interactions and resource management
 - Target execution time: <100ms per test
 

--- a/docs/MVP_CAPABILITY_SUMMARY.md
+++ b/docs/MVP_CAPABILITY_SUMMARY.md
@@ -7,7 +7,7 @@ CycleTime CE is a project orchestration framework that extends Claude Code to ma
 ## Core Capabilities (Available Today)
 
 ### 1. Claude Code Integration ✅
-- **MCP WebSocket Server**: Claude Code integration via MCP protocol
+- **MCP SSE Server**: Claude Code integration via MCP protocol (v2024-11-05)
 - **Operational Tools**: Project, issue, workflow, and session management capabilities
 - **Resource Providers**: Context access for AI-assisted development
 - **Cross-Session Persistence**: H2 database maintains state between sessions
@@ -43,7 +43,7 @@ CycleTime CE is a project orchestration framework that extends Claude Code to ma
 docker run -p 8080:8080 ghcr.io/spiralhouse/cycletime:latest
 
 # 2. Connect Claude Code
-# Add MCP server configuration pointing to localhost:8080/mcp
+# Add MCP server configuration pointing to http://localhost:8080/mcp/events
 
 # 3. Start orchestrating!
 # Use Claude Code to create projects, track issues, manage workflows

--- a/docs/architecture/decisions/ADR-006-lifecycle-managed-cleanup.md
+++ b/docs/architecture/decisions/ADR-006-lifecycle-managed-cleanup.md
@@ -1,5 +1,7 @@
 # ADR-006: Lifecycle-Managed Connection Cleanup Service
 
+> **Historical Note**: This document describes the WebSocket-based MCP implementation that was superseded by SSE (Server-Sent Events) transport in SPI-665 (October 2025). CycleTime now uses SSE transport following MCP specification v2024-11-05. For current implementation details, see [MCP Client Setup](../../getting-started/mcp-client-setup.md) and [MCP Integration Patterns](mcp-integration-patterns.md).
+
 ## Status
 Accepted
 

--- a/docs/archive/audits/phase-2-reference.md
+++ b/docs/archive/audits/phase-2-reference.md
@@ -1,5 +1,7 @@
 # Reference & Getting Started Domain Audit Report (Phase 2)
 
+> **Historical Note**: This document references the WebSocket-based MCP implementation that was superseded by SSE (Server-Sent Events) transport in SPI-665 (MCP specification v2024-11-05). WebSocket references in this audit reflect the architecture at the time of writing (2025-10-01) and do not represent the current SSE-based implementation.
+
 **Audit Date**: 2025-10-01
 **Domain**: Reference & Getting Started
 **Files Reviewed**: 42 files (LARGEST domain - 45.2% of all docs)

--- a/docs/ci-cd/overview.md
+++ b/docs/ci-cd/overview.md
@@ -392,7 +392,7 @@ outputs: type=docker,dest=/tmp/cycletime-image.tar
 **Test Coverage**:
 - **Health Endpoint**: Validates `/health` endpoint response
 - **MCP Endpoints**: Tests `/mcp`, `/mcp/tools`, `/mcp/resources` accessibility
-- **WebSocket Connectivity**: Verifies WebSocket endpoint at `/ws`
+- **SSE Connectivity**: Verifies SSE endpoint at `/mcp/events`
 - **Container Startup Time**: Ensures startup within 30 seconds
 - **Resource Usage**: Validates memory usage under 512MB
 - **Port Accessibility**: Confirms host-to-container port mapping
@@ -645,7 +645,7 @@ The container publishing process implements multiple validation gates to ensure 
 **Gate 2: Smoke Test Validation** (Container Smoke Tests Job)
 - Health endpoint response validation
 - MCP server endpoint accessibility
-- WebSocket connectivity verification
+- SSE connectivity verification
 - Resource usage validation (< 512MB memory)
 - Container startup time verification (< 30 seconds)
 - Port accessibility from host system

--- a/docs/development/mcp-development.md
+++ b/docs/development/mcp-development.md
@@ -53,7 +53,8 @@ MCP_DETAILED_LOGGING=true ./gradlew run
 ```
 
 The server will be available at:
-- **WebSocket**: `ws://localhost:8080/mcp`
+- **SSE Events**: `http://localhost:8080/mcp/events`
+- **POST Requests**: `http://localhost:8080/mcp`
 - **Server Info**: `http://localhost:8080/mcp`
 - **Statistics**: `http://localhost:8080/mcp/stats`
 
@@ -131,8 +132,8 @@ Connect Claude Code to your local MCP server:
    {
      "mcpServers": {
        "cycletime-local": {
-         "transport": "websocket",
-         "url": "ws://localhost:8080/mcp"
+         "transport": "sse",
+         "url": "http://localhost:8080/mcp/events"
        }
      }
    }
@@ -140,21 +141,26 @@ Connect Claude Code to your local MCP server:
 3. **Restart Claude Code** to load the configuration
 4. **Verify Connection** by checking available tools
 
-### WebSocket Test Client (wscat)
+### SSE Test Client (curl)
 
 For protocol-level testing:
 
 ```bash
-# Install wscat
-npm install -g wscat
+# Connect to SSE endpoint (receive events)
+curl -N -H "Accept: text/event-stream" http://localhost:8080/mcp/events
 
-# Connect to server
-wscat -c ws://localhost:8080/mcp
+# Send JSON-RPC requests via POST
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}'
 
-# Test JSON-RPC requests
-> {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}
-> {"jsonrpc":"2.0","id":2,"method":"tools/list"}
-> {"jsonrpc":"2.0","id":3,"method":"resources/list"}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"resources/list"}'
 ```
 
 ### HTTP Test Requests
@@ -256,9 +262,10 @@ Tool(
 **3. Verify Tool Registration**
 
 ```bash
-# Using wscat
-wscat -c ws://localhost:8080/mcp
-> {"jsonrpc":"2.0","id":1,"method":"tools/list"}
+# Using curl
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 
 # Look for "archive_project" in response
 ```
@@ -304,11 +311,14 @@ override suspend fun readResource(uri: String): String {
 
 ```bash
 # List resources
-wscat -c ws://localhost:8080/mcp
-> {"jsonrpc":"2.0","id":1,"method":"resources/list"}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"resources/list"}'
 
 # Read resource content
-> {"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"project://recent"}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"project://recent"}}'
 ```
 
 ## Debugging MCP Issues
@@ -326,7 +336,7 @@ MCP_SLOW_REQUEST_MS=50 \
 ```
 
 This enables:
-- **Connection Lifecycle**: WebSocket connect/disconnect events
+- **Connection Lifecycle**: SSE connection/disconnect events
 - **Request/Response Details**: Full JSON-RPC message logging
 - **Performance Timing**: Request duration tracking
 - **Slow Request Warnings**: Alerts for requests exceeding threshold
@@ -337,7 +347,7 @@ Monitor server logs for MCP events:
 
 ```bash
 # Start server and watch logs
-./gradlew run | grep -E "(MCP|WebSocket)"
+./gradlew run | grep -E "(MCP|SSE)"
 
 # Filter for specific events
 ./gradlew run 2>&1 | grep "MCP.*error"
@@ -345,29 +355,29 @@ Monitor server logs for MCP events:
 
 Key log patterns:
 - `MCP Configuration loaded` - Server startup
-- `MCP WebSocket connection` - Client connection events
+- `MCP SSE connection` - Client connection events
 - `Tool execution:` - Tool invocation traces
 - `Resource read:` - Resource access traces
 - `ERROR` - Error conditions and stack traces
 
-### WebSocket Frame Inspection
+### SSE Stream Inspection
 
 **Browser DevTools Method**:
 
-1. Navigate to `http://localhost:8080/mcp` in Chrome/Firefox
+1. Navigate to `http://localhost:8080/mcp/events` in Chrome/Firefox
 2. Open DevTools (F12)
 3. Go to Network tab
-4. Click on WebSocket connection
-5. View frames being sent/received
+4. Click on the SSE connection (EventStream type)
+5. View events being received in real-time
 
-**Wireshark Method**:
+**curl Method**:
 
 ```bash
-# Capture WebSocket traffic
-sudo tcpdump -i lo0 -A 'tcp port 8080'
+# Monitor SSE stream with verbose output
+curl -N -v -H "Accept: text/event-stream" http://localhost:8080/mcp/events
 
-# Filter for WebSocket frames in Wireshark
-tcp.port == 8080 && websocket
+# Capture and analyze SSE traffic
+sudo tcpdump -i lo0 -A 'tcp port 8080 and host localhost' | grep -A 5 "data:"
 ```
 
 ### JSON-RPC Protocol Debugging
@@ -375,22 +385,30 @@ tcp.port == 8080 && websocket
 Test protocol handling directly:
 
 ```bash
-wscat -c ws://localhost:8080/mcp
-
 # Test initialize
-> {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}'
 
 # Test invalid method
-> {"jsonrpc":"2.0","id":2,"method":"invalid_method"}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"invalid_method"}'
 
 # Test malformed JSON
-> {invalid json}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{invalid json}'
 
 # Test missing required parameters
-> {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"create_project"}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"create_project"}}'
 
 # Test tool execution
-> {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_projects","arguments":{}}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_projects","arguments":{}}}'
 ```
 
 ### Common Issues and Solutions
@@ -412,8 +430,9 @@ curl http://localhost:8080/mcp
 
 ```bash
 # List all registered tools
-wscat -c ws://localhost:8080/mcp
-> {"jsonrpc":"2.0","id":1,"method":"tools/list"}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 
 # Check ToolProvider registration in logs
 ./gradlew run | grep "ToolProvider"
@@ -423,11 +442,14 @@ wscat -c ws://localhost:8080/mcp
 
 ```bash
 # List available resources
-wscat -c ws://localhost:8080/mcp
-> {"jsonrpc":"2.0","id":1,"method":"resources/list"}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"resources/list"}'
 
 # Test resource read with exact URI
-> {"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"project://stats"}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"project://stats"}}'
 ```
 
 **Issue: Invalid Schema Validation**
@@ -605,16 +627,20 @@ handler = ToolHandler.Async { params ->
 Test with invalid inputs:
 
 ```bash
-wscat -c ws://localhost:8080/mcp
-
 # Missing required parameter
-> {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_project","arguments":{}}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_project","arguments":{}}}'
 
 # Invalid parameter format
-> {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_project","arguments":{"id":"invalid-id-format"}}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_project","arguments":{"id":"invalid-id-format"}}}'
 
 # Non-existent resource
-> {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_project","arguments":{"id":"00000000-0000-0000-0000-000000000000"}}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_project","arguments":{"id":"00000000-0000-0000-0000-000000000000"}}}'
 ```
 
 ### Adding Custom Response Formats
@@ -689,8 +715,9 @@ MCP_DETAILED_LOGGING=true ./gradlew run --continuous
 
 **Terminal 3: Manual testing**
 ```bash
-wscat -c ws://localhost:8080/mcp
-# Interactively test protocol changes
+# Monitor SSE stream
+curl -N -H "Accept: text/event-stream" http://localhost:8080/mcp/events
+# Or test JSON-RPC requests via POST
 ```
 
 **Terminal 4: Log monitoring**
@@ -736,14 +763,14 @@ class ProjectToolProviderTest : StringSpec({
 
 ### Integration Testing MCP Server
 
-Test WebSocket connections and request handling using `MCPIntegrationTestBase`:
+Test SSE connections and request handling using `MCPIntegrationTestBase`:
 
 ```kotlin
 class MCPServerIntegrationTest : MCPIntegrationTestBase() {
     init {
-        "should accept WebSocket connection and perform handshake" {
+        "should accept SSE connection and perform handshake" {
             withTestApplication {
-                // Create and initialize MCP client (handles connection internally)
+                // Create and initialize MCP client (handles SSE connection internally)
                 val client = createInitializedMcpClient(
                     clientName = "Test-Client",
                     protocolVersion = "2024-11-05"
@@ -765,7 +792,7 @@ class MCPServerIntegrationTest : MCPIntegrationTestBase() {
 **Key Testing Patterns**:
 - Extend `MCPIntegrationTestBase` for automatic test infrastructure setup
 - Use `withTestApplication {}` which calls `module()` to configure full app including MCP routes
-- Use `createConnectedMcpClient()` or `createInitializedMcpClient()` for WebSocket connections
+- Use `createConnectedMcpClient()` or `createInitializedMcpClient()` for SSE connections
 - MCPIntegrationTestBase provides validation helpers: `validateJsonRpcResponse()`, `validateToolsList()`, etc.
 
 ### Manual Testing Checklist
@@ -778,7 +805,7 @@ Before committing MCP changes:
 - [ ] Tool execution with valid parameters succeeds
 - [ ] Tool execution with invalid parameters returns proper errors
 - [ ] Resource reads return correct content
-- [ ] WebSocket connection handles disconnects gracefully
+- [ ] SSE connection handles disconnects gracefully
 - [ ] Performance metrics show acceptable latency
 - [ ] Unit tests pass
 - [ ] Integration tests pass
@@ -791,11 +818,10 @@ Before committing MCP changes:
 |----------|---------|-------------|
 | `MCP_HOST` | `0.0.0.0` | Server bind address |
 | `MCP_PORT` | `8080` | Server port |
-| `MCP_PATH` | `/mcp` | WebSocket endpoint path |
+| `MCP_SSE_PATH` | `/mcp/events` | SSE endpoint path |
+| `MCP_POST_PATH` | `/mcp` | POST endpoint path |
 | `MCP_ENABLED` | `true` | Enable MCP server |
-| `MCP_PING_PERIOD` | `30000` | WebSocket ping interval (ms) |
 | `MCP_TIMEOUT` | `15000` | Connection timeout (ms) |
-| `MCP_MAX_FRAME_SIZE` | `10485760` | Max WebSocket frame size (10MB) |
 | `MCP_MAX_CONNECTIONS` | `100` | Maximum concurrent connections |
 | `MCP_ASYNC_ENABLED` | `true` | Enable async tool processing |
 | `MCP_CACHE_ENABLED` | `true` | Enable resource caching |

--- a/docs/development/project-structure.md
+++ b/docs/development/project-structure.md
@@ -93,7 +93,7 @@ cycletime/                               # Root project directory
 │   │   │       ├── resources/       # MCP resources for Claude Code
 │   │   │       ├── server/          # MCP server core
 │   │   │       ├── tools/           # MCP tools for operations
-│   │   │       └── websocket/       # WebSocket transport
+│   │   │       └── sse/             # SSE transport
 │   │   └── resources/                 # Resources
 │   │       ├── application.conf       # Ktor configuration
 │   │       └── META-INF/              # Metadata
@@ -214,7 +214,7 @@ io.spiralhouse.cycletime/
     ├── resources/    # MCP Resources for Claude Code
     ├── server/       # MCP server core functionality
     ├── tools/        # MCP Tools for operations
-    └── websocket/    # WebSocket transport layer
+    └── sse/          # SSE transport layer
 ```
 
 ### 3. Dependency Rules

--- a/docs/getting-started/mcp-client-setup.md
+++ b/docs/getting-started/mcp-client-setup.md
@@ -12,41 +12,45 @@ Before configuring the MCP client connection, ensure you have:
 
 ## Connection Overview
 
-CycleTime exposes an MCP server over WebSocket that Claude Code connects to for real-time project data access and tool execution.
+CycleTime exposes an MCP server using SSE (Server-Sent Events) transport that Claude Code connects to for real-time project data access and tool execution, following the MCP specification v2024-11-05.
 
 ```mermaid
 sequenceDiagram
     participant CC as Claude Code
-    participant WS as WebSocket Server
+    participant SSE as SSE Endpoint
+    participant POST as POST Endpoint
     participant MCP as MCP Server
     participant DB as Project Database
 
-    CC->>WS: Connect ws://localhost:8080/mcp
-    WS->>MCP: Initialize Connection
+    CC->>SSE: Connect http://localhost:8080/mcp/events (SSE)
+    SSE->>MCP: Initialize Session
     MCP->>DB: Load Project Context
     DB-->>MCP: Project Data
-    MCP-->>CC: Connection Ready
+    MCP-->>SSE: Connection Ready
 
-    CC->>MCP: Request Resources/Tools
+    CC->>POST: POST /mcp (JSON-RPC Request)
+    POST->>MCP: Process Request
     MCP->>DB: Query Data
     DB-->>MCP: Results
-    MCP-->>CC: Response
+    MCP-->>SSE: Response via EventBus
+    SSE-->>CC: Server-Sent Event
 ```
 
 ## MCP Server Configuration
 
-CycleTime's MCP server uses WebSocket transport with JSON-RPC 2.0 protocol.
+CycleTime's MCP server uses SSE (Server-Sent Events) transport with JSON-RPC 2.0 protocol, following MCP specification v2024-11-05.
 
 ### Default Configuration
 
 | Setting | Default Value | Description |
 |---------|--------------|-------------|
 | **Protocol Version** | `2024-11-05` | MCP protocol version |
-| **Transport** | WebSocket | Communication protocol |
+| **Transport** | SSE | Communication protocol (Server-Sent Events) |
 | **Host** | `0.0.0.0` | Server bind address |
 | **Port** | `8080` | Server port |
-| **Path** | `/mcp` | WebSocket endpoint path |
-| **WebSocket URL** | `ws://localhost:8080/mcp` | Full connection URL |
+| **SSE Endpoint** | `/mcp/events` | Server-to-client event stream path |
+| **POST Endpoint** | `/mcp` | Client-to-server JSON-RPC request path |
+| **SSE URL** | `http://localhost:8080/mcp/events` | Full SSE connection URL |
 
 ### Server Capabilities
 
@@ -80,11 +84,10 @@ MCP_PORT=3006 MCP_HOST=127.0.0.1 MCP_DETAILED_LOGGING=true ./gradlew run
 |----------|---------|-------------|
 | `MCP_HOST` | `0.0.0.0` | Server bind address |
 | `MCP_PORT` | `8080` | Server port |
-| `MCP_PATH` | `/mcp` | WebSocket endpoint path |
+| `MCP_SSE_PATH` | `/mcp/events` | SSE endpoint path (server-to-client) |
+| `MCP_POST_PATH` | `/mcp` | POST endpoint path (client-to-server) |
 | `MCP_ENABLED` | `true` | Enable/disable MCP server |
-| `MCP_PING_PERIOD` | `30000` | WebSocket ping interval (ms) |
 | `MCP_TIMEOUT` | `15000` | Connection timeout (ms) |
-| `MCP_MAX_FRAME_SIZE` | `10485760` | Max WebSocket frame size (10MB) |
 | `MCP_MAX_CONNECTIONS` | `100` | Maximum concurrent connections |
 | `MCP_DETAILED_LOGGING` | `false` | Enable debug-level logging |
 | `MCP_METRICS_ENABLED` | `true` | Enable metrics collection |
@@ -113,8 +116,8 @@ Add the following configuration to connect to CycleTime:
 {
   "mcpServers": {
     "cycletime": {
-      "command": "websocket",
-      "url": "ws://localhost:8080/mcp"
+      "type": "sse",
+      "url": "http://localhost:8080/mcp/events"
     }
   }
 }
@@ -128,8 +131,8 @@ If you have other MCP servers configured:
 {
   "mcpServers": {
     "cycletime": {
-      "command": "websocket",
-      "url": "ws://localhost:8080/mcp"
+      "type": "sse",
+      "url": "http://localhost:8080/mcp/events"
     },
     "other-server": {
       "command": "node",
@@ -147,8 +150,8 @@ If you changed the MCP server port, update the URL accordingly:
 {
   "mcpServers": {
     "cycletime": {
-      "command": "websocket",
-      "url": "ws://localhost:3006/mcp"
+      "type": "sse",
+      "url": "http://localhost:3006/mcp/events"
     }
   }
 }
@@ -268,20 +271,20 @@ MCP_PORT=3006 ./gradlew run
 # url: "ws://localhost:3006/mcp"
 ```
 
-### WebSocket Handshake Failed
+### SSE Connection Failed
 
-**Symptom**: Connection attempts fail with handshake error
+**Symptom**: Connection attempts fail or timeout
 
-**Cause**: Incorrect WebSocket path or protocol mismatch
+**Cause**: Incorrect SSE endpoint path or URL format
 
 **Solution**:
 ```json
-// Verify configuration uses correct WebSocket URL format
+// Verify configuration uses correct SSE URL format
 {
   "mcpServers": {
     "cycletime": {
-      "command": "websocket",
-      "url": "ws://localhost:8080/mcp"  // Not "http://" or missing "/mcp"
+      "type": "sse",
+      "url": "http://localhost:8080/mcp/events"  // Must be HTTP(S) with /mcp/events path
     }
   }
 }
@@ -302,9 +305,9 @@ curl http://localhost:8080/mcp
 # On macOS
 sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
 
-# Verify WebSocket endpoint is accessible
-wscat -c ws://localhost:8080/mcp
-# (Install wscat: npm install -g wscat)
+# Test SSE endpoint directly
+curl -N http://localhost:8080/mcp/events
+# Should establish an SSE connection (press Ctrl+C to exit)
 
 # Enable detailed logging to diagnose
 MCP_DETAILED_LOGGING=true ./gradlew run
@@ -331,8 +334,8 @@ cat ~/.claude.json | jq .
 {
   "mcpServers": {
     "cycletime": {
-      "command": "websocket",
-      "url": "ws://localhost:8080/mcp"
+      "type": "sse",
+      "url": "http://localhost:8080/mcp/events"
     }
   }
 }
@@ -442,12 +445,12 @@ Configure multiple servers in Claude Code:
 {
   "mcpServers": {
     "cycletime-projectA": {
-      "command": "websocket",
-      "url": "ws://localhost:8080/mcp"
+      "type": "sse",
+      "url": "http://localhost:8080/mcp/events"
     },
     "cycletime-projectB": {
-      "command": "websocket",
-      "url": "ws://localhost:8081/mcp"
+      "type": "sse",
+      "url": "http://localhost:8081/mcp/events"
     }
   }
 }
@@ -455,7 +458,7 @@ Configure multiple servers in Claude Code:
 
 ### SSL/TLS Configuration
 
-For secure WebSocket connections (wss://):
+For secure SSE connections (https://):
 
 ```bash
 # Configure SSL in application.conf
@@ -465,8 +468,8 @@ For secure WebSocket connections (wss://):
 {
   "mcpServers": {
     "cycletime": {
-      "command": "websocket",
-      "url": "wss://localhost:8443/mcp"
+      "type": "sse",
+      "url": "https://localhost:8443/mcp/events"
     }
   }
 }
@@ -494,10 +497,10 @@ flowchart TB
     ParseConfig -->|Yes| StartServer{Server Running?}
 
     StartServer -->|No| Error2[Show Connection Refused]
-    StartServer -->|Yes| WSConnect[WebSocket Connect]
+    StartServer -->|Yes| SSEConnect[Connect to SSE Endpoint]
 
-    WSConnect --> Handshake{Handshake OK?}
-    Handshake -->|No| Error3[Show Handshake Failed]
+    SSEConnect --> Handshake{Connection OK?}
+    Handshake -->|No| Error3[Show SSE Connection Failed]
     Handshake -->|Yes| InitProtocol[Initialize MCP Protocol]
 
     InitProtocol --> GetCapabilities[Request Server Capabilities]
@@ -506,19 +509,19 @@ flowchart TB
     ShowConnected --> Ready([Ready for Use])
 
     Ready --> UserRequest[User Requests Resource/Tool]
-    UserRequest --> MCPRequest[Send JSON-RPC Request]
+    UserRequest --> MCPRequest[Send JSON-RPC via POST]
     MCPRequest --> ServerProcess[Server Processes Request]
-    ServerProcess --> MCPResponse[Receive JSON-RPC Response]
+    ServerProcess --> MCPResponse[Response via SSE EventBus]
     MCPResponse --> DisplayResult[Display Result to User]
     DisplayResult --> Ready
 
     Error1 --> Fix1[Fix Configuration File]
     Error2 --> Fix2[Start CycleTime Server]
-    Error3 --> Fix3[Check WebSocket URL]
+    Error3 --> Fix3[Check SSE URL & Endpoints]
 
     Fix1 --> LoadConfig
     Fix2 --> StartServer
-    Fix3 --> WSConnect
+    Fix3 --> SSEConnect
 
     style Start fill:#d4edda
     style Ready fill:#d1ecf1

--- a/docs/getting-started/mcp-client-setup.md
+++ b/docs/getting-started/mcp-client-setup.md
@@ -268,7 +268,7 @@ netstat -ano | findstr :8080
 MCP_PORT=3006 ./gradlew run
 
 # Update Claude Code configuration to match
-# url: "ws://localhost:3006/mcp"
+# url: "http://localhost:3006/mcp/events"
 ```
 
 ### SSE Connection Failed

--- a/docs/getting-started/mcp-testing.md
+++ b/docs/getting-started/mcp-testing.md
@@ -4,13 +4,13 @@ Comprehensive testing and verification procedures for CycleTime's Model Context 
 
 ## Overview
 
-This guide provides step-by-step procedures to verify MCP functionality, test protocol compliance, and troubleshoot connection issues. The CycleTime MCP server provides WebSocket-based communication following the MCP specification version 2024-11-05.
+This guide provides step-by-step procedures to verify MCP functionality, test protocol compliance, and troubleshoot connection issues. The CycleTime MCP server provides SSE (Server-Sent Events) transport following the MCP specification version 2024-11-05.
 
 **MCP Endpoints**:
-- **WebSocket**: `ws://localhost:8080/mcp` - Primary MCP protocol communication
+- **SSE Stream**: `GET http://localhost:8080/mcp/events` - Server-to-client event stream (MCP v2024-11-05)
+- **POST Endpoint**: `POST http://localhost:8080/mcp` - Client-to-server JSON-RPC requests
 - **Server Info**: `GET http://localhost:8080/mcp` - Server metadata and capabilities
 - **Statistics**: `GET http://localhost:8080/mcp/stats` - Connection metrics and monitoring
-- **SSE Events**: `GET http://localhost:8080/mcp/events` - Server-sent events (legacy support)
 
 ## Prerequisites
 
@@ -27,11 +27,12 @@ java -version
 
 **Testing Tools**:
 ```bash
-# Install wscat for WebSocket testing
-npm install -g wscat
+# curl for HTTP/SSE testing (usually pre-installed)
+curl --version
 
-# Or use websocat (alternative)
-brew install websocat  # macOS
+# jq for JSON formatting (optional but recommended)
+brew install jq  # macOS
+sudo apt-get install jq  # Linux
 ```
 
 **HTTP Client**:
@@ -153,37 +154,37 @@ curl http://localhost:8080/mcp/stats
 # Response: {"error": "Metrics disabled"}
 ```
 
-## WebSocket Connectivity Tests
+## SSE Connectivity Tests
 
-### 3. Basic WebSocket Connection
+### 3. Basic SSE Connection
 
-**Using wscat**:
+**Using curl**:
 ```bash
-wscat -c ws://localhost:8080/mcp
+# Connect to SSE endpoint (server-to-client event stream)
+curl -N http://localhost:8080/mcp/events
 ```
 
 **Expected Output**:
 ```
-Connected (press CTRL+C to quit)
+# Connection established, waiting for server events
+# (Connection stays open, press CTRL+C to exit)
 ```
 
 **Verification**:
 - Connection establishes without errors
-- No immediate disconnection
-- Ready to send/receive messages
+- curl stays connected (doesn't immediately exit)
+- Server may send periodic keep-alive events
 
-**Connection Test**:
+**Alternative test with headers**:
 ```bash
-# Send ping frame
-> ping
+# Show HTTP headers during connection
+curl -N -v http://localhost:8080/mcp/events
 
-# Expected: pong response
-< pong
-```
-
-**Using websocat** (alternative):
-```bash
-websocat ws://localhost:8080/mcp
+# Expected headers:
+# < HTTP/1.1 200 OK
+# < Content-Type: text/event-stream
+# < Cache-Control: no-cache
+# < Connection: keep-alive
 ```
 
 ### 4. MCP Protocol Handshake
@@ -675,48 +676,46 @@ websocat ws://localhost:8080/mcp
 - [ ] MIME type is application/json
 - [ ] Text field contains valid JSON
 
-## Complete WebSocket Test Session
+## Complete SSE + POST Test Session
 
-**Full test sequence using wscat**:
+**Full test sequence using curl and POST**:
 
 ```bash
-# 1. Connect
-wscat -c ws://localhost:8080/mcp
+# Terminal 1: Establish SSE connection (server-to-client events)
+curl -N http://localhost:8080/mcp/events
 
-# 2. Initialize (paste and press Enter)
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}
+# Terminal 2: Send JSON-RPC requests via POST (client-to-server)
 
-# Wait for init response, then:
+# 1. Initialize
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0.0"}}}'
 
-# 3. List tools
-{"jsonrpc":"2.0","id":2,"method":"tools/list"}
+# 2. List tools
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type": "application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
 
-# 4. List resources
-{"jsonrpc":"2.0","id":3,"method":"resources/list"}
+# 3. List resources
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type": "application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"resources/list"}'
 
-# 5. Execute tool
-{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_projects","arguments":{}}}
+# 4. Execute tool
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type": "application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_projects","arguments":{}}}'
 
-# 6. Read resource
-{"jsonrpc":"2.0","id":5,"method":"resources/read","params":{"uri":"cycletime://session/current"}}
-
-# 7. Close connection (Ctrl+C)
+# 5. Read resource
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type": "application/json" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"resources/read","params":{"uri":"cycletime://session/current"}}'
 ```
 
 **Expected Flow**:
-```
-Connected (press CTRL+C to quit)
-> {"jsonrpc":"2.0","id":1,"method":"initialize",...}
-< {"jsonrpc":"2.0","id":1,"result":{...}}
-> {"jsonrpc":"2.0","id":2,"method":"tools/list"}
-< {"jsonrpc":"2.0","id":2,"result":{"tools":[...]}}
-> {"jsonrpc":"2.0","id":3,"method":"resources/list"}
-< {"jsonrpc":"2.0","id":3,"result":{"resources":[...]}}
-> {"jsonrpc":"2.0","id":4,"method":"tools/call",...}
-< {"jsonrpc":"2.0","id":4,"result":{"content":[...]}}
-> {"jsonrpc":"2.0","id":5,"method":"resources/read",...}
-< {"jsonrpc":"2.0","id":5,"result":{"contents":[...]}}
-```
+- **Terminal 1 (SSE)**: Receives server-sent events with JSON-RPC responses
+- **Terminal 2 (POST)**: Sends JSON-RPC requests, receives immediate HTTP responses
+- Responses correlate via EventBus + MessageCorrelator using request IDs
 
 ## Debugging and Troubleshooting
 
@@ -774,21 +773,26 @@ lsof -i :8080
 - Check port availability: `lsof -i :8080`
 - Verify no firewall blocking port 8080
 
-**Issue: WebSocket Upgrade Failed**
+**Issue: SSE Connection Failed**
 ```bash
-wscat -c ws://localhost:8080/mcp
-error: Unexpected server response: 404
+curl -N http://localhost:8080/mcp/events
+# No response or immediate disconnect
 ```
 
 **Diagnosis**:
 ```bash
-# Verify endpoint exists
+# Verify SSE endpoint exists
+curl -v http://localhost:8080/mcp/events
+# Should return HTTP 200 with Content-Type: text/event-stream
+
+# Verify POST endpoint exists
 curl http://localhost:8080/mcp
-# Should return server info, not 404
+# Should return server info JSON
 ```
 
 **Solution**:
-- Confirm correct path: `/mcp` (not `/mcp/ws` or other variations)
+- Confirm correct SSE path: `/mcp/events` for server-to-client stream
+- Confirm correct POST path: `/mcp` for client-to-server requests
 - Check server logs for routing errors
 - Verify MCP module loaded: look for "MCP routing configured" in logs
 
@@ -1046,7 +1050,8 @@ MCP_DETAILED_LOGGING=true MCP_CACHE_ENABLED=true ./gradlew run
 # Connection
 MCP_HOST=0.0.0.0              # Bind address
 MCP_PORT=8080                  # Server port
-MCP_PATH=/mcp                  # WebSocket path
+MCP_SSE_PATH=/mcp/events       # SSE endpoint (server-to-client)
+MCP_POST_PATH=/mcp             # POST endpoint (client-to-server)
 
 # Performance
 MCP_MAX_CONNECTIONS=100        # Max concurrent connections
@@ -1063,10 +1068,9 @@ MCP_METRICS_ENABLED=true       # Enable statistics
 MCP_SLOW_REQUEST_MS=100        # Slow request threshold
 MCP_DETAILED_LOGGING=false     # Verbose logging
 
-# WebSocket
-MCP_PING_PERIOD=30000          # Ping interval (ms)
+# Connection Settings
 MCP_TIMEOUT=15000              # Connection timeout (ms)
-MCP_MAX_FRAME_SIZE=10485760    # Max frame size (10MB)
+MCP_SESSION_TIMEOUT=3600000    # Session timeout (1 hour)
 ```
 
 ## Related Documentation

--- a/docs/getting-started/mcp-testing.md
+++ b/docs/getting-started/mcp-testing.md
@@ -53,7 +53,8 @@ brew install httpie  # macOS
 ./gradlew run
 
 # Server starts at http://localhost:8080
-# WebSocket endpoint: ws://localhost:8080/mcp
+# SSE endpoint: http://localhost:8080/mcp/events
+# POST endpoint: http://localhost:8080/mcp
 ```
 
 **Development Mode with Hot Reload**:
@@ -166,12 +167,12 @@ curl -N http://localhost:8080/mcp/events
 
 **Expected Output**:
 ```
-# Connection established, waiting for server events
+# SSE connection established, waiting for server events
 # (Connection stays open, press CTRL+C to exit)
 ```
 
 **Verification**:
-- Connection establishes without errors
+- SSE connection establishes without errors
 - curl stays connected (doesn't immediately exit)
 - Server may send periodic keep-alive events
 
@@ -729,7 +730,7 @@ MCP_DETAILED_LOGGING=true ./gradlew run
 
 **Log Output** (example):
 ```
-[MCP] WebSocket connection established from /127.0.0.1:54321
+[MCP] SSE connection established from /127.0.0.1:54321
 [MCP] Received request: method=initialize, id=1
 [MCP] Processing initialize request...
 [MCP] Sending response: id=1, size=234 bytes
@@ -941,10 +942,10 @@ Use this checklist to verify complete MCP functionality:
 - [ ] Capabilities show resources=true, tools=true
 - [ ] GET /mcp/stats returns connection metrics (if enabled)
 
-### WebSocket Connectivity
-- [ ] WebSocket connection to ws://localhost:8080/mcp succeeds
+### SSE Connectivity
+- [ ] SSE connection to http://localhost:8080/mcp/events succeeds
 - [ ] Connection remains open and stable
-- [ ] Ping/pong frames work correctly
+- [ ] Keep-alive events work correctly
 
 ### MCP Protocol
 - [ ] Initialize handshake completes successfully
@@ -989,13 +990,13 @@ Use this checklist to verify complete MCP functionality:
 
 **Test multiple clients**:
 ```bash
-# Terminal 1
-wscat -c ws://localhost:8080/mcp
+# Terminal 1: First SSE connection
+curl -N http://localhost:8080/mcp/events
 
-# Terminal 2
-wscat -c ws://localhost:8080/mcp
+# Terminal 2: Second SSE connection
+curl -N http://localhost:8080/mcp/events
 
-# Terminal 3
+# Terminal 3: Check active connections
 curl http://localhost:8080/mcp | jq .activeConnections
 # Should show 2
 ```
@@ -1018,13 +1019,15 @@ curl http://localhost:8080/mcp/stats | jq '.connections.totalRequests'
 
 **Long-running connection test**:
 ```bash
-# Connect and leave idle
-wscat -c ws://localhost:8080/mcp
+# Terminal 1: Open SSE connection and leave idle
+curl -N http://localhost:8080/mcp/events
 
-# Wait 5 minutes, then send request
-{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+# Terminal 2: Wait 5 minutes, then send request via POST
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 
-# Verify: Should still respond normally
+# Verify: Should still respond normally via SSE in Terminal 1
 # Connection should survive ping/timeout mechanisms
 ```
 

--- a/docs/reference/PRD.md
+++ b/docs/reference/PRD.md
@@ -387,7 +387,7 @@ graph TB
     end
 
     subgraph "CycleTime"
-        MCP[MCP Server<br/>WebSocket]
+        MCP[MCP Server<br/>SSE Transport]
         API[REST API]
         APP[Application Layer<br/>DDD Services]
         DOMAIN[Domain Layer<br/>Entities & Rules]

--- a/docs/reference/mcp-troubleshooting.md
+++ b/docs/reference/mcp-troubleshooting.md
@@ -209,143 +209,144 @@ MCP_ENABLED=true ./gradlew run
 
 ---
 
-## Issue 2: WebSocket Handshake Failed
+## Issue 2: SSE Connection Failed
 
 ### Symptoms
 
 ```bash
-$ wscat -c ws://localhost:8080
-error: Unexpected server response: 404
+$ curl -N http://localhost:8080/mcp/events
+curl: (52) Empty reply from server
 ```
 
 ```bash
-$ wscat -c wss://localhost:8080/mcp
-error: Error: socket hang up
+$ curl -N https://localhost:8080/mcp/events
+curl: (60) SSL certificate problem
 ```
 
 **Observable Behavior**:
-- HTTP 400/404 errors during WebSocket upgrade
+- HTTP 400/404 errors when connecting to SSE endpoint
 - Connection closes immediately after attempt
-- "Unexpected server response" errors
-- SSL/TLS errors with `wss://` protocol
+- "Empty reply from server" errors
+- SSL/TLS errors with `https://` protocol
 
 ### Root Causes
 
-1. **Incorrect WebSocket URL**
-   - Missing `/mcp` path
-   - Wrong protocol (`wss://` instead of `ws://` for local)
+1. **Incorrect SSE endpoint URL**
+   - Missing `/mcp/events` path
+   - Wrong protocol (`https://` instead of `http://` for local)
    - Wrong host or port
 
-2. **Server not configured for WebSocket upgrade**
-   - HTTP endpoint exists but WebSocket not initialized
+2. **Server not configured for SSE**
+   - HTTP endpoint exists but SSE stream not initialized
    - Path mismatch between client and server
 
 3. **SSL/TLS configuration issues**
-   - Using `wss://` without SSL certificate
+   - Using `https://` without SSL certificate
    - Certificate validation failures
 
 ### Step-by-Step Solutions
 
-**Solution 1: Use correct WebSocket URL**
+**Solution 1: Use correct SSE endpoint URL**
 
 ```bash
-# ✅ CORRECT - Local development
-wscat -c ws://localhost:8080/mcp
+# ✅ CORRECT - Local development (SSE stream)
+curl -N http://localhost:8080/mcp/events
 
-# ❌ WRONG - Missing path
-wscat -c ws://localhost:8080
+# ❌ WRONG - Missing /events path
+curl -N http://localhost:8080/mcp
 
 # ❌ WRONG - Wrong protocol for local
-wscat -c wss://localhost:8080/mcp
+curl -N https://localhost:8080/mcp/events
 
 # ❌ WRONG - Wrong path
-wscat -c ws://localhost:8080/ws
+curl -N http://localhost:8080/ws
 ```
 
-**Solution 2: Verify server info before WebSocket connection**
+**Solution 2: Verify server info before SSE connection**
 
 ```bash
-# Step 1: Check HTTP endpoint
+# Step 1: Check HTTP server info endpoint
 curl http://localhost:8080/mcp
 
-# Step 2: Verify capabilities include WebSocket
-# Look for: "transports": ["websocket"]
+# Step 2: Verify capabilities include resources and tools
+# Look for: "capabilities": {"resources": true, "tools": true}
 
-# Step 3: Connect to WebSocket
-wscat -c ws://localhost:8080/mcp
+# Step 3: Connect to SSE stream
+curl -N http://localhost:8080/mcp/events
 ```
 
 **Solution 3: Test with custom path configuration**
 
 ```bash
-# Start server with custom path
-MCP_PATH=/custom ./gradlew run
+# Start server with custom SSE path
+MCP_SSE_PATH=/custom/events ./gradlew run
 
 # Connect using custom path
-wscat -c ws://localhost:8080/custom
+curl -N http://localhost:8080/custom/events
 
-# Verify with HTTP endpoint
-curl http://localhost:8080/custom
+# Verify with HTTP endpoint (POST path may differ)
+curl http://localhost:8080/mcp
 ```
 
-**Solution 4: Debug WebSocket handshake**
+**Solution 4: Debug SSE connection**
 
 ```bash
-# Use curl to see handshake details
+# Use curl with verbose output to see connection details
 curl -i -N \
-  -H "Connection: Upgrade" \
-  -H "Upgrade: websocket" \
-  -H "Sec-WebSocket-Version: 13" \
-  -H "Sec-WebSocket-Key: test" \
-  http://localhost:8080/mcp
+  -H "Accept: text/event-stream" \
+  http://localhost:8080/mcp/events
 
 # Expected response:
-# HTTP/1.1 101 Switching Protocols
-# Upgrade: websocket
-# Connection: upgrade
+# HTTP/1.1 200 OK
+# Content-Type: text/event-stream
+# Cache-Control: no-cache
+# Connection: keep-alive
 ```
 
 ### Prevention Tips
 
-- **Document WebSocket URL format**: Include in API documentation
+- **Document SSE endpoint URLs**: Include in API documentation
   ```
-  Local: ws://localhost:8080/mcp
-  Production: wss://api.example.com/mcp
+  Local SSE: http://localhost:8080/mcp/events
+  Local POST: http://localhost:8080/mcp
+  Production SSE: https://api.example.com/mcp/events
+  Production POST: https://api.example.com/mcp
   ```
 
 - **Consistent path configuration**: Use environment variables
   ```bash
-  export MCP_PATH=/mcp
+  export MCP_SSE_PATH=/mcp/events
+  export MCP_POST_PATH=/mcp
   ```
 
 - **Client configuration validation**: Validate URLs before connection
   ```kotlin
-  // Validate WebSocket URL (Ktor client)
+  // Validate SSE endpoint URL
   import io.ktor.http.*
 
-  fun validateMcpUrl(wsUrl: String) {
-      val url = Url(wsUrl)
-      require(url.protocol == URLProtocol.WS || url.protocol == URLProtocol.WSS) {
-          "Invalid WebSocket protocol: ${url.protocol.name}"
+  fun validateMcpSseUrl(sseUrl: String) {
+      val url = Url(sseUrl)
+      require(url.protocol == URLProtocol.HTTP || url.protocol == URLProtocol.HTTPS) {
+          "Invalid SSE protocol: ${url.protocol.name}"
       }
-      require(url.encodedPath.startsWith("/mcp")) {
-          "Invalid MCP path: ${url.encodedPath}"
+      require(url.encodedPath.contains("/events")) {
+          "Invalid MCP SSE path: ${url.encodedPath} (must contain /events)"
       }
   }
   ```
 
-- **Health check integration**: Test WebSocket connectivity in CI
+- **Health check integration**: Test SSE connectivity in CI
   ```bash
   #!/bin/bash
-  echo "Testing WebSocket handshake..."
-  wscat -c ws://localhost:8080/mcp --execute "exit" || exit 1
+  echo "Testing SSE connection..."
+  timeout 5 curl -N -f http://localhost:8080/mcp/events || exit 1
   ```
 
 ### Related Configuration
 
-- `MCPConfiguration.kt:21` - MCP path setting
-- `MCPConfiguration.kt:25-28` - WebSocket settings
-- Environment: `MCP_PATH`, `MCP_TIMEOUT`
+- `MCPConfiguration.kt:21` - MCP SSE path setting
+- `MCPConfiguration.kt:25-28` - SSE connection settings
+- Environment: `MCP_SSE_PATH`, `MCP_POST_PATH`, `MCP_TIMEOUT`
 
 ---
 
@@ -354,8 +355,8 @@ curl -i -N \
 ### Symptoms
 
 ```bash
-$ wscat -c ws://localhost:8080/mcp
-error: Error: Connection timeout
+$ curl -N --max-time 15 http://localhost:8080/mcp/events
+curl: (28) Operation timed out after 15000 milliseconds
 ```
 
 **Observable Behavior**:
@@ -393,28 +394,23 @@ error: Error: Connection timeout
 # "Application started in X.XX seconds."
 # "MCP server listening on 0.0.0.0:8080"
 
-# Then connect
-wscat -c ws://localhost:8080/mcp
+# Then connect to SSE stream
+curl -N http://localhost:8080/mcp/events
 ```
 
 **Solution 2: Increase client timeout**
 
 ```bash
-# Increase timeout in client configuration
-# Example with wscat
-wscat -c ws://localhost:8080/mcp --timeout 30000
+# Increase timeout with curl
+curl -N --max-time 30 http://localhost:8080/mcp/events
 ```
 
 ```kotlin
-// Example with Ktor WebSocket client
+// Example with Ktor SSE client
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
-import io.ktor.client.plugins.websocket.*
 
 val client = HttpClient(CIO) {
-    install(WebSockets) {
-        pingInterval = 30_000  // 30 seconds
-    }
     engine {
         requestTimeout = 30_000  // 30 seconds
     }
@@ -434,7 +430,7 @@ MCP_TIMEOUT=30000 ./gradlew run
 **Solution 4: Test HTTP endpoint first**
 
 ```bash
-# Quick health check before WebSocket
+# Quick health check before SSE connection
 curl -f http://localhost:8080/mcp || echo "Server not ready"
 
 # Retry with backoff
@@ -444,8 +440,8 @@ for i in {1..10}; do
   sleep 2
 done
 
-# Then connect WebSocket
-wscat -c ws://localhost:8080/mcp
+# Then connect to SSE stream
+curl -N http://localhost:8080/mcp/events
 ```
 
 **Solution 5: Check server resource usage**
@@ -484,11 +480,8 @@ pkill -f gradle
   ```
 
   ```kotlin
-  // Ktor client timeout configuration
+  // Ktor SSE client timeout configuration
   val client = HttpClient(CIO) {
-      install(WebSockets) {
-          pingInterval = 30_000
-      }
       engine {
           requestTimeout = 30_000
       }
@@ -503,18 +496,21 @@ pkill -f gradle
 - **Use connection retry logic**: Implement exponential backoff
   ```kotlin
   import io.ktor.client.*
-  import io.ktor.client.plugins.websocket.*
+  import io.ktor.client.request.*
+  import io.ktor.client.statement.*
   import kotlinx.coroutines.delay
   import kotlin.math.pow
 
-  suspend fun connectWithRetry(
+  suspend fun connectSseWithRetry(
       client: HttpClient,
       url: String,
       maxRetries: Int = 5
-  ): DefaultWebSocketSession {
+  ): HttpResponse {
       repeat(maxRetries) { attempt ->
           try {
-              return client.webSocketSession(url)
+              return client.get(url) {
+                  header("Accept", "text/event-stream")
+              }
           } catch (e: Exception) {
               if (attempt == maxRetries - 1) throw e
               val backoffMs = 2.0.pow(attempt).toLong() * 1000
@@ -527,7 +523,7 @@ pkill -f gradle
 
 ### Related Configuration
 
-- `MCPConfiguration.kt:26` - WebSocket timeout
+- `MCPConfiguration.kt:26` - SSE connection timeout
 - `MCPConfiguration.kt:34` - Request timeout
 - Environment: `MCP_TIMEOUT`, `MCP_REQUEST_TIMEOUT`
 
@@ -639,25 +635,42 @@ fun createJsonRpcRequest(method: String, params: JsonObject = JsonObject(emptyMa
     return Json.encodeToString(request)
 }
 
-// Usage with WebSocket session
-suspend fun DefaultWebSocketSession.sendJsonRpcRequest(method: String, params: JsonObject = JsonObject(emptyMap())) {
+// Usage with HTTP POST (client-to-server)
+suspend fun HttpClient.sendJsonRpcRequest(
+    url: String,
+    method: String,
+    params: JsonObject = JsonObject(emptyMap())
+): HttpResponse {
     val request = createJsonRpcRequest(method, params)
-    send(Frame.Text(request))
+    return this.post(url) {
+        header("Content-Type", "application/json")
+        setBody(request)
+    }
 }
 ```
 
 **Solution 3: Test with known-good requests**
 
 ```bash
+# Terminal 1: Open SSE stream to receive responses
+curl -N http://localhost:8080/mcp/events
+
+# Terminal 2: Send JSON-RPC requests via POST
+
 # Test tools/list
-wscat -c ws://localhost:8080/mcp
-> {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 
 # Test resources/list
-> {"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}'
 
 # Test tool call
-> {
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
     "jsonrpc":"2.0",
     "id":3,
     "method":"tools/call",
@@ -665,14 +678,16 @@ wscat -c ws://localhost:8080/mcp
       "name":"create_project",
       "arguments":{"name":"Test Project","description":"Test"}
     }
-  }
+  }'
 ```
 
 **Solution 4: Handle JSON parsing errors**
 
 ```kotlin
-// Client error handling with Ktor WebSocket
-import io.ktor.websocket.*
+// Client error handling with HTTP POST responses
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 
@@ -690,28 +705,33 @@ data class JsonRpcResponse(
     val error: JsonRpcError? = null
 )
 
-suspend fun handleWebSocketMessages(session: DefaultWebSocketSession) {
-    for (frame in session.incoming) {
-        if (frame is Frame.Text) {
-            try {
-                val text = frame.readText()
-                val response = Json.decodeFromString<JsonRpcResponse>(text)
-
-                if (response.error != null) {
-                    println("JSON-RPC Error: ${response.error}")
-                    // Handle specific error codes
-                    when (response.error.code) {
-                        -32600 -> println("Invalid Request - check JSON-RPC format")
-                        -32601 -> println("Method not found")
-                        -32602 -> println("Invalid params")
-                    }
-                } else {
-                    println("Success: ${response.result}")
-                }
-            } catch (e: SerializationException) {
-                println("Failed to parse response: ${e.message}")
-            }
+suspend fun sendAndHandleJsonRpcRequest(
+    client: HttpClient,
+    url: String,
+    requestBody: String
+) {
+    try {
+        val response: HttpResponse = client.post(url) {
+            header("Content-Type", "application/json")
+            setBody(requestBody)
         }
+
+        val responseText = response.bodyAsText()
+        val jsonRpcResponse = Json.decodeFromString<JsonRpcResponse>(responseText)
+
+        if (jsonRpcResponse.error != null) {
+            println("JSON-RPC Error: ${jsonRpcResponse.error}")
+            // Handle specific error codes
+            when (jsonRpcResponse.error.code) {
+                -32600 -> println("Invalid Request - check JSON-RPC format")
+                -32601 -> println("Method not found")
+                -32602 -> println("Invalid params")
+            }
+        } else {
+            println("Success: ${jsonRpcResponse.result}")
+        }
+    } catch (e: SerializationException) {
+        println("Failed to parse response: ${e.message}")
     }
 }
 ```
@@ -720,30 +740,31 @@ suspend fun handleWebSocketMessages(session: DefaultWebSocketSession) {
 
 - **Use JSON-RPC client libraries**: Avoid manual formatting
   ```kotlin
-  // Create a reusable JSON-RPC client with Ktor
+  // Create a reusable JSON-RPC client with Ktor HTTP
   import io.ktor.client.*
-  import io.ktor.client.plugins.websocket.*
+  import io.ktor.client.request.*
+  import io.ktor.client.statement.*
   import kotlinx.serialization.json.*
 
-  class JsonRpcClient(private val url: String) {
-      private val client = HttpClient(CIO) {
-          install(WebSockets)
-      }
+  class JsonRpcClient(private val postUrl: String) {
+      private val client = HttpClient(CIO)
 
       suspend fun call(method: String, params: JsonObject = JsonObject(emptyMap())): JsonElement? {
-          return client.webSocketSession(url).use { session ->
-              val request = createJsonRpcRequest(method, params, id = 1)
-              session.send(Frame.Text(request))
+          val request = createJsonRpcRequest(method, params, id = 1)
 
-              val frame = session.incoming.receive() as Frame.Text
-              val response = Json.decodeFromString<JsonRpcResponse>(frame.readText())
-              response.result
+          val response: HttpResponse = client.post(postUrl) {
+              header("Content-Type", "application/json")
+              setBody(request)
           }
+
+          val responseText = response.bodyAsText()
+          val jsonRpcResponse = Json.decodeFromString<JsonRpcResponse>(responseText)
+          return jsonRpcResponse.result
       }
   }
 
   // Usage
-  val client = JsonRpcClient("ws://localhost:8080/mcp")
+  val client = JsonRpcClient("http://localhost:8080/mcp")
   client.call("tools/list")
   ```
 
@@ -772,11 +793,14 @@ suspend fun handleWebSocketMessages(session: DefaultWebSocketSession) {
 
 - **Request logging**: Log all requests for debugging
   ```kotlin
-  // Log WebSocket messages
-  suspend fun DefaultWebSocketSession.sendWithLogging(message: String) {
-      val formatted = Json.parseToJsonElement(message).toString()
+  // Log HTTP POST messages
+  suspend fun HttpClient.postWithLogging(url: String, body: String): HttpResponse {
+      val formatted = Json.parseToJsonElement(body).toString()
       println("[SEND] $formatted")
-      send(Frame.Text(message))
+      return this.post(url) {
+          header("Content-Type", "application/json")
+          setBody(body)
+      }
   }
   ```
 
@@ -842,14 +866,16 @@ suspend fun handleWebSocketMessages(session: DefaultWebSocketSession) {
 **Solution 1: List available tools**
 
 ```bash
-# Connect to MCP server
-wscat -c ws://localhost:8080/mcp
+# Terminal 1: Open SSE stream to receive responses
+curl -N http://localhost:8080/mcp/events
 
-# List all available tools
-> {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+# Terminal 2: Send tools/list request via POST
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 
-# Response shows available tools
-< {
+# Response shows available tools (received in Terminal 1 via SSE)
+{
     "jsonrpc": "2.0",
     "result": {
       "tools": [
@@ -883,13 +909,19 @@ wscat -c ws://localhost:8080/mcp
 
 ```bash
 # ✅ CORRECT - snake_case naming
-> {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create_project","arguments":{"name":"Test"}}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create_project","arguments":{"name":"Test"}}}'
 
 # ❌ WRONG - camelCase naming
-> {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"createProject","arguments":{"name":"Test"}}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"createProject","arguments":{"name":"Test"}}}'
 
 # ❌ WRONG - kebab-case naming
-> {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create-project","arguments":{"name":"Test"}}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"create-project","arguments":{"name":"Test"}}}'
 ```
 
 **Solution 3: Verify tool provider configuration**
@@ -909,13 +941,17 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
 **Solution 4: Test tool with correct parameters**
 
 ```bash
-# Get tool schema first
-> {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+# Get tool schema first via POST
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 
-# Check inputSchema for required parameters
+# Check inputSchema for required parameters in SSE response
 # Then call with correct parameters
 
-> {
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
     "jsonrpc":"2.0",
     "id":2,
     "method":"tools/call",
@@ -927,7 +963,7 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
         "startDate":"2024-01-01"
       }
     }
-  }
+  }'
 ```
 
 ### Prevention Tips
@@ -941,6 +977,10 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
 - **Tool discovery on connect**: List tools after connection
   ```kotlin
   import kotlinx.serialization.json.*
+  import io.ktor.client.*
+  import io.ktor.client.request.*
+  import io.ktor.client.statement.*
+
   // Discover available tools
   @Serializable
   data class ToolInfo(val name: String, val description: String)
@@ -948,12 +988,16 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
   @Serializable
   data class ToolsResult(val tools: List<ToolInfo>)
 
-  suspend fun discoverTools(session: DefaultWebSocketSession): List<String> {
+  suspend fun discoverTools(client: HttpClient, postUrl: String): List<String> {
       val request = createJsonRpcRequest("tools/list", JsonObject(emptyMap()), id = 1)
-      session.send(Frame.Text(request))
 
-      val frame = session.incoming.receive() as Frame.Text
-      val response = Json.decodeFromString<JsonRpcResponse>(frame.readText())
+      val httpResponse: HttpResponse = client.post(postUrl) {
+          header("Content-Type", "application/json")
+          setBody(request)
+      }
+
+      val responseText = httpResponse.bodyAsText()
+      val response = Json.decodeFromString<JsonRpcResponse>(responseText)
       val toolsResult = Json.decodeFromJsonElement<ToolsResult>(response.resultOrThrow())
 
       val toolNames = toolsResult.tools.map { it.name }
@@ -966,11 +1010,15 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
   ```kotlin
   // Tool validation before calling
   import kotlinx.serialization.json.*
-  class ValidatedToolClient(private val session: DefaultWebSocketSession) {
+  import io.ktor.client.*
+  import io.ktor.client.request.*
+  import io.ktor.client.statement.*
+
+  class ValidatedToolClient(private val client: HttpClient, private val postUrl: String) {
       private lateinit var availableTools: List<String>
 
       suspend fun initialize() {
-          availableTools = discoverTools(session)
+          availableTools = discoverTools(client, postUrl)
       }
 
       suspend fun callTool(name: String, arguments: JsonObject): JsonElement {
@@ -983,10 +1031,14 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
               put("arguments", arguments)
           }
           val request = createJsonRpcRequest("tools/call", params, id = 1)
-          session.send(Frame.Text(request))
 
-          val frame = session.incoming.receive() as Frame.Text
-          val response = Json.decodeFromString<JsonRpcResponse>(frame.readText())
+          val httpResponse: HttpResponse = client.post(postUrl) {
+              header("Content-Type", "application/json")
+              setBody(request)
+          }
+
+          val responseText = httpResponse.bodyAsText()
+          val response = Json.decodeFromString<JsonRpcResponse>(responseText)
           return response.resultOrThrow()
       }
   }
@@ -1065,14 +1117,16 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
 **Solution 1: List available resources**
 
 ```bash
-# Connect to MCP server
-wscat -c ws://localhost:8080/mcp
+# Terminal 1: Open SSE stream to receive responses
+curl -N http://localhost:8080/mcp/events
 
-# List all available resources
-> {"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}
+# Terminal 2: Send resources/list request via POST
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}'
 
-# Response shows available resource templates
-< {
+# Response shows available resource templates (received in Terminal 1 via SSE)
+{
     "jsonrpc": "2.0",
     "result": {
       "resources": [
@@ -1131,10 +1185,13 @@ cycletime://projectList  # Should be "projects"
 **Solution 3: Verify resource exists before reading**
 
 ```bash
-# Step 1: List resources to find valid IDs
-> {"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"cycletime://projects"}}
+# Step 1: List resources to find valid IDs (via POST)
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"cycletime://projects"}}'
 
-< {
+# Response (received via SSE):
+{
     "jsonrpc": "2.0",
     "result": {
       "contents": [
@@ -1149,7 +1206,9 @@ cycletime://projectList  # Should be "projects"
   }
 
 # Step 2: Read specific resource using valid ID
-> {"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"cycletime://projects/proj_abc123"}}
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"cycletime://projects/proj_abc123"}}'
 ```
 
 **Solution 4: Check resource provider registration**
@@ -1203,6 +1262,10 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
 - **Resource discovery**: List resources on startup
   ```kotlin
   import kotlinx.serialization.json.*
+  import io.ktor.client.*
+  import io.ktor.client.request.*
+  import io.ktor.client.statement.*
+
   // Discover available resources
   @Serializable
   data class ResourceInfo(val uri: String, val name: String, val description: String, val mimeType: String)
@@ -1210,12 +1273,16 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
   @Serializable
   data class ResourcesResult(val resources: List<ResourceInfo>)
 
-  suspend fun discoverResources(session: DefaultWebSocketSession): List<ResourceInfo> {
+  suspend fun discoverResources(client: HttpClient, postUrl: String): List<ResourceInfo> {
       val request = createJsonRpcRequest("resources/list", JsonObject(emptyMap()), id = 1)
-      session.send(Frame.Text(request))
 
-      val frame = session.incoming.receive() as Frame.Text
-      val response = Json.decodeFromString<JsonRpcResponse>(frame.readText())
+      val httpResponse: HttpResponse = client.post(postUrl) {
+          header("Content-Type", "application/json")
+          setBody(request)
+      }
+
+      val responseText = httpResponse.bodyAsText()
+      val response = Json.decodeFromString<JsonRpcResponse>(responseText)
       val resourcesResult = Json.decodeFromJsonElement<ResourcesResult>(response.resultOrThrow())
 
       println("Available resources: ${resourcesResult.resources.map { it.uri }}")
@@ -1227,10 +1294,14 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
   ```kotlin
   // Type-safe resource client
   import kotlinx.serialization.json.*
+  import io.ktor.client.*
+  import io.ktor.client.request.*
+  import io.ktor.client.statement.*
+
   @Serializable
   data class Session(val id: String, val projectId: String, val active: Boolean)
 
-  class ResourceClient(private val session: DefaultWebSocketSession) {
+  class ResourceClient(private val client: HttpClient, private val postUrl: String) {
       suspend fun getProjects(): List<Project> {
           return read("cycletime://projects")
       }
@@ -1246,10 +1317,14 @@ cat src/main/kotlin/io/spiralhouse/cycletime/mcp/MCPModule.kt
       private suspend inline fun <reified T> read(uri: String): T {
           val params = buildJsonObject { put("uri", uri) }
           val request = createJsonRpcRequest("resources/read", params, id = 1)
-          session.send(Frame.Text(request))
 
-          val frame = this.session.incoming.receive() as Frame.Text
-          val response = Json.decodeFromString<JsonRpcResponse>(frame.readText())
+          val httpResponse: HttpResponse = client.post(postUrl) {
+              header("Content-Type", "application/json")
+              setBody(request)
+          }
+
+          val responseText = httpResponse.bodyAsText()
+          val response = Json.decodeFromString<JsonRpcResponse>(responseText)
           return Json.decodeFromJsonElement(response.resultOrThrow())
       }
   }
@@ -1669,9 +1744,6 @@ DATABASE_LOGGING=true MCP_REQUEST_TIMEOUT=120000 ./gradlew run
   // Server timeout: 60s
   // Client timeout: 65s (5s buffer)
   val client = HttpClient(CIO) {
-      install(WebSockets) {
-          pingInterval = 30_000
-      }
       engine {
           requestTimeout = 65_000  // 5s buffer over server timeout
       }
@@ -1947,8 +2019,8 @@ lsof -i :8080  # Should show nothing
 # Start server on alternative port
 MCP_PORT=3006 ./gradlew run
 
-# Update client configuration
-wscat -c ws://localhost:3006/mcp
+# Update client configuration for SSE connection
+curl -N http://localhost:3006/mcp/events
 
 # Or use environment variable
 export MCP_PORT=3006
@@ -2105,25 +2177,27 @@ fi
 echo -n "Server info: "
 curl -s http://localhost:8080/mcp | jq -r '.name + " v" + .version'
 
-# Check WebSocket
-echo -n "WebSocket: "
-if echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | wscat -c ws://localhost:8080/mcp -w 1 > /dev/null 2>&1; then
+# Check SSE connectivity
+echo -n "SSE Connection: "
+if timeout 2 curl -N -f http://localhost:8080/mcp/events > /dev/null 2>&1; then
   echo "✅ OK"
 else
   echo "❌ FAILED"
 fi
 
-# Check tools
+# Check tools via POST endpoint
 echo "Available tools:"
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
-  wscat -c ws://localhost:8080/mcp -w 1 2>/dev/null | \
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
   jq -r '.result.tools[].name' | \
   sed 's/^/  - /'
 
-# Check resources
+# Check resources via POST endpoint
 echo "Available resources:"
-echo '{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}' | \
-  wscat -c ws://localhost:8080/mcp -w 1 2>/dev/null | \
+curl -s -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}' | \
   jq -r '.result.resources[].uri' | \
   sed 's/^/  - /'
 
@@ -2175,18 +2249,17 @@ echo "1. Testing HTTP endpoint..."
 curl -v http://localhost:8080/mcp 2>&1 | grep -E "(HTTP|connected|Server)"
 
 echo ""
-echo "2. Testing WebSocket upgrade..."
-curl -v \
-  -H "Connection: Upgrade" \
-  -H "Upgrade: websocket" \
-  -H "Sec-WebSocket-Version: 13" \
-  -H "Sec-WebSocket-Key: test" \
-  http://localhost:8080/mcp 2>&1 | grep -E "(HTTP|Upgrade)"
+echo "2. Testing SSE endpoint..."
+curl -v -N \
+  -H "Accept: text/event-stream" \
+  --max-time 2 \
+  http://localhost:8080/mcp/events 2>&1 | grep -E "(HTTP|Content-Type)"
 
 echo ""
-echo "3. Testing JSON-RPC request..."
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | \
-  wscat -c ws://localhost:8080/mcp -w 1 2>&1
+echo "3. Testing JSON-RPC request via POST..."
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' 2>&1
 
 echo ""
 echo "=== Debug Complete ==="
@@ -2210,7 +2283,7 @@ echo "=== Debug Complete ==="
 | Code | Meaning | Common Causes |
 |------|---------|---------------|
 | 404 | Not Found | Wrong path, MCP disabled, server not started |
-| 400 | Bad Request | Malformed WebSocket upgrade request |
+| 400 | Bad Request | Malformed SSE connection request, incorrect headers |
 | 500 | Internal Server Error | Server crash, unhandled exception |
 | 503 | Service Unavailable | Server overloaded, database down |
 
@@ -2219,10 +2292,10 @@ echo "=== Debug Complete ==="
 When encountering MCP issues:
 
 - [ ] Verify server is running: `curl http://localhost:8080/mcp`
-- [ ] Check correct WebSocket URL: `ws://localhost:8080/mcp`
+- [ ] Check SSE connection: `curl -N http://localhost:8080/mcp/events`
 - [ ] Validate JSON-RPC format: Include `jsonrpc`, `id`, `method`
-- [ ] List available tools: `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
-- [ ] List available resources: `{"jsonrpc":"2.0","id":1,"method":"resources/list"}`
+- [ ] List available tools via POST: `curl -X POST http://localhost:8080/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`
+- [ ] List available resources via POST: `curl -X POST http://localhost:8080/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"resources/list"}'`
 - [ ] Check server logs: `./gradlew run | grep -i error`
 - [ ] Verify port availability: `lsof -i :8080`
 - [ ] Enable metrics: `MCP_METRICS_ENABLED=true ./gradlew run`

--- a/docs/reference/mcp-troubleshooting.md
+++ b/docs/reference/mcp-troubleshooting.md
@@ -13,7 +13,7 @@ This guide addresses the top 10 common MCP issues encountered during development
 | Issue | Problem | Jump To |
 |-------|---------|---------|
 | #1 | Connection Refused | [→](#issue-1-connection-refused) |
-| #2 | WebSocket Handshake Failed | [→](#issue-2-websocket-handshake-failed) |
+| #2 | SSE Connection Failed | [→](#issue-2-sse-connection-failed) |
 | #3 | Connection Timeout | [→](#issue-3-connection-timeout) |
 | #4 | Invalid JSON-RPC Request | [→](#issue-4-invalid-json-rpc-request) |
 | #5 | Tool Not Found | [→](#issue-5-tool-not-found) |
@@ -31,17 +31,17 @@ This guide addresses the top 10 common MCP issues encountered during development
 sequenceDiagram
     participant Client
     participant HTTP as HTTP Endpoint
-    participant WS as WebSocket
+    participant SSE as SSE Events
     participant MCP as MCP Server
     participant DB as Database
 
     Client->>HTTP: GET /mcp (Server Info)
     HTTP-->>Client: JSON (name, version, capabilities)
 
-    Client->>WS: Upgrade to WebSocket
-    WS-->>Client: 101 Switching Protocols
+    Client->>SSE: GET /mcp/events (Accept: text/event-stream)
+    SSE-->>Client: 200 OK + SSE Stream
 
-    Client->>MCP: JSON-RPC Request
+    Client->>HTTP: POST /mcp (JSON-RPC Request)
     MCP->>DB: Query/Update
     DB-->>MCP: Result
     MCP-->>Client: JSON-RPC Response
@@ -54,13 +54,13 @@ Understanding default configuration helps diagnose issues quickly:
 **Connection Settings** (MCPConfiguration.kt):
 - Host: `0.0.0.0` (all interfaces)
 - Port: `8080`
-- Path: `/mcp`
+- SSE Path: `/mcp/events`
+- POST Path: `/mcp`
 - Enabled: `true`
 
-**WebSocket Settings**:
-- Ping period: `30000ms` (30 seconds)
+**SSE Settings**:
 - Timeout: `15000ms` (15 seconds)
-- Max frame size: `10485760` bytes (10MB)
+- Keep-alive interval: `30000ms` (30 seconds)
 
 **Performance Settings**:
 - Request timeout: `60000ms` (60 seconds)
@@ -72,8 +72,9 @@ Understanding default configuration helps diagnose issues quickly:
 MCP_ENABLED=true          # Enable/disable MCP server
 MCP_HOST=0.0.0.0          # Bind address
 MCP_PORT=8080             # Server port
-MCP_PATH=/mcp             # WebSocket path
-MCP_TIMEOUT=15000         # WebSocket timeout (ms)
+MCP_SSE_PATH=/mcp/events  # SSE endpoint path
+MCP_POST_PATH=/mcp        # POST endpoint path
+MCP_TIMEOUT=15000         # Connection timeout (ms)
 MCP_REQUEST_TIMEOUT=60000 # Request timeout (ms)
 MCP_SLOW_REQUEST_MS=100   # Slow request threshold
 MCP_METRICS_ENABLED=true  # Enable metrics (default: true)
@@ -92,8 +93,8 @@ curl: (7) Failed to connect to localhost port 8080: Connection refused
 ```
 
 ```bash
-$ wscat -c ws://localhost:8080/mcp
-error: Error: connect ECONNREFUSED 127.0.0.1:8080
+$ curl -N -H "Accept: text/event-stream" http://localhost:8080/mcp/events
+curl: (7) Failed to connect to localhost port 8080: Connection refused
 ```
 
 **Observable Behavior**:

--- a/docs/reference/technical-design/configuration-management.md
+++ b/docs/reference/technical-design/configuration-management.md
@@ -114,20 +114,22 @@ cycletime {
     
     mcp {
         enabled = true
-        
-        websocket {
-            path = "/mcp"
-            pingInterval = 30000
+
+        sse {
+            path = "/mcp/events"
             timeout = 15000
-            maxFrameSize = 1048576  # 1MB
         }
-        
+
+        post {
+            path = "/mcp"
+        }
+
         resources {
             maxListSize = 1000
             cacheEnabled = true
             cacheTtl = 300000  # 5 minutes
         }
-        
+
         tools {
             maxConcurrent = 10
             timeout = 30000
@@ -297,10 +299,14 @@ cycletime {
     
     mcp {
         enabled = true
-        
-        websocket {
-            pingInterval = 1000
+
+        sse {
+            path = "/mcp/events"
             timeout = 5000
+        }
+
+        post {
+            path = "/mcp"
         }
     }
     
@@ -478,7 +484,8 @@ data class PoolConfig(
 @Serializable
 data class MCPConfig(
     val enabled: Boolean,
-    val websocket: WebSocketConfig,
+    val sse: SSEConfig,
+    val post: PostConfig,
     val resources: ResourceConfig,
     val tools: ToolConfig
 )
@@ -613,8 +620,8 @@ class ConfigurationService(
         
         // MCP validation
         if (config.mcp.enabled) {
-            require(config.mcp.websocket.path.isNotBlank()) {
-                "MCP WebSocket path is required"
+            require(config.mcp.sse.path.isNotBlank()) {
+                "MCP SSE path is required"
             }
         }
     }
@@ -1103,14 +1110,18 @@ class ConfigurationValidator {
     }
     
     private fun validateMCP(config: MCPConfig, errors: MutableList<ValidationError>) {
-        if (config.websocket.path.isBlank()) {
-            errors.add(ValidationError("mcp.websocket.path", "WebSocket path cannot be blank"))
+        if (config.sse.path.isBlank()) {
+            errors.add(ValidationError("mcp.sse.path", "SSE path cannot be blank"))
         }
-        
-        if (config.websocket.pingInterval <= 0) {
-            errors.add(ValidationError("mcp.websocket.pingInterval", "Ping interval must be positive"))
+
+        if (config.post.path.isBlank()) {
+            errors.add(ValidationError("mcp.post.path", "POST path cannot be blank"))
         }
-        
+
+        if (config.sse.timeout <= 0) {
+            errors.add(ValidationError("mcp.sse.timeout", "SSE timeout must be positive"))
+        }
+
         if (config.tools.maxConcurrent <= 0) {
             errors.add(ValidationError("mcp.tools.maxConcurrent", "Max concurrent must be positive"))
         }

--- a/docs/reference/technical-design/dependency-injection-patterns.md
+++ b/docs/reference/technical-design/dependency-injection-patterns.md
@@ -778,10 +778,15 @@ fun Application.configureMCP() {
     // Resources are already injected via DI
     mcpServer.start()
     
-    // Register WebSocket endpoint
+    // Register SSE endpoint
     routing {
-        webSocket("/mcp") {
-            mcpServer.handleConnection(this)
+        sse("/mcp/events") {
+            mcpServer.handleSseConnection(this)
+        }
+
+        // POST endpoint for requests
+        post("/mcp") {
+            mcpServer.handlePost(call)
         }
     }
 }
@@ -1059,9 +1064,12 @@ database {
 mcp {
     server {
         enabled = true
-        websocket {
+        sse {
+            path = "/mcp/events"
+            timeout = 15000
+        }
+        post {
             path = "/mcp"
-            pingInterval = 30000
         }
     }
 }

--- a/docs/reference/technical-design/mcp-architecture-simplification.md
+++ b/docs/reference/technical-design/mcp-architecture-simplification.md
@@ -1,5 +1,7 @@
 # MCP Architecture Simplification: Technical Design
 
+> **Historical Note**: This document describes the WebSocket-based MCP implementation that was superseded by SSE (Server-Sent Events) transport in SPI-665 (October 2025). CycleTime now uses SSE transport following MCP specification v2024-11-05. For current implementation details, see [MCP Client Setup](../../getting-started/mcp-client-setup.md) and [MCP Integration Patterns](mcp-integration-patterns.md).
+
 **Document Status**: Technical Design  
 **Linear Issue**: [SPI-611](https://linear.app/spiral-house/issue/SPI-611/simplify-mcp-architecture-collapse-78-files-to-20)  
 **Target**: Reduce from 79 files to ~35 files  

--- a/docs/reference/technical-design/mcp-integration-patterns.md
+++ b/docs/reference/technical-design/mcp-integration-patterns.md
@@ -340,20 +340,46 @@ class CycleTimeMCPServer(
 }
 
 /**
- * MCP session representing a connected client
+ * MCP session representing a connected client via SSE
  */
 data class MCPSession(
     val id: String,
-    private val websocket: WebSocketSession
+    private val sseSession: ServerSentEventSession,
+    private val eventBus: EventBus
 ) {
     suspend fun send(message: String) {
-        websocket.send(Frame.Text(message))
+        // Send message via EventBus for delivery through SSE stream
+        eventBus.publish(Event(sessionId = id, data = message))
     }
-    
+
     suspend fun close() {
-        websocket.close(CloseReason(CloseReason.Codes.NORMAL, "Session ended"))
+        sseSession.close()
     }
 }
+
+/**
+ * EventBus for server-to-client event delivery via SSE
+ */
+class EventBus {
+    private val channels = ConcurrentHashMap<String, Channel<Event>>()
+
+    suspend fun subscribe(sessionId: String): Channel<Event> {
+        return channels.getOrPut(sessionId) { Channel(Channel.UNLIMITED) }
+    }
+
+    suspend fun publish(event: Event) {
+        channels[event.sessionId]?.send(event)
+    }
+
+    fun unsubscribe(sessionId: String) {
+        channels.remove(sessionId)?.close()
+    }
+}
+
+data class Event(
+    val sessionId: String,
+    val data: String
+)
 ```
 
 ### JSON-RPC Data Models
@@ -1013,125 +1039,184 @@ fun Application.configureMCP() {
 
 ## Testing MCP Integration
 
-### WebSocket Testing
+### SSE + POST Endpoint Testing
 
 ```kotlin
 // src/test/kotlin/io/spiralhouse/cycletime/mcp/MCPServerTest.kt
 
-import io.ktor.client.plugins.websocket.*
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.*
 
 class MCPServerTest : DescribeSpec({
-    
+
     describe("MCP Server") {
-        
-        describe("WebSocket connection") {
-            it("should handle MCP handshake") {
+
+        describe("SSE connection") {
+            it("should establish SSE event stream") {
                 testApplication {
                     application {
                         configureDependencies()
                         configureMCP()
                     }
-                    
-                    val client = createClient {
-                        install(WebSockets)
+
+                    val client = createClient()
+
+                    // Connect to SSE endpoint
+                    val response = client.get("/mcp/events") {
+                        header(HttpHeaders.Accept, "text/event-stream")
                     }
-                    
-                    client.webSocket("/mcp") {
-                        // Send initialize
-                        val initRequest = buildJsonObject {
-                            put("jsonrpc", "2.0")
-                            put("method", "initialize")
-                            put("id", 1)
-                            put("params", buildJsonObject {
-                                put("protocolVersion", "1.0")
-                                put("clientInfo", buildJsonObject {
-                                    put("name", "test")
-                                    put("version", "1.0")
-                                })
-                            })
-                        }
-                        
-                        send(Frame.Text(initRequest.toString()))
-                        
-                        val response = incoming.receive() as Frame.Text
-                        val json = Json.parseToJsonElement(response.readText()).jsonObject
-                        
-                        json["jsonrpc"]?.jsonPrimitive?.content shouldBe "2.0"
-                        json["id"]?.jsonPrimitive?.int shouldBe 1
-                        json["result"]?.jsonObject?.get("protocolVersion")?.jsonPrimitive?.content shouldBe "1.0"
-                    }
+
+                    response.status shouldBe HttpStatusCode.OK
+                    response.headers[HttpHeaders.ContentType] shouldBe "text/event-stream"
                 }
             }
         }
-        
+
+        describe("POST endpoint") {
+            it("should handle MCP initialize handshake") {
+                testApplication {
+                    application {
+                        configureDependencies()
+                        configureMCP()
+                    }
+
+                    val client = createClient()
+
+                    // Send initialize request via POST
+                    val initRequest = buildJsonObject {
+                        put("jsonrpc", "2.0")
+                        put("method", "initialize")
+                        put("id", 1)
+                        put("params", buildJsonObject {
+                            put("protocolVersion", "2024-11-05")
+                            put("clientInfo", buildJsonObject {
+                                put("name", "test")
+                                put("version", "1.0")
+                            })
+                        })
+                    }
+
+                    val response = client.post("/mcp") {
+                        contentType(ContentType.Application.Json)
+                        setBody(initRequest.toString())
+                    }
+
+                    val json = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+
+                    json["jsonrpc"]?.jsonPrimitive?.content shouldBe "2.0"
+                    json["id"]?.jsonPrimitive?.int shouldBe 1
+                    json["result"]?.jsonObject?.get("protocolVersion")?.jsonPrimitive?.content shouldBe "2024-11-05"
+                }
+            }
+        }
+
         describe("Resource operations") {
-            it("should list available resources") {
-                testApplication {
-                    TestFixtures.withProject { projectId ->
-                        client.webSocket("/mcp") {
-                            MCPTestHelper.initialize(this)
-                            
-                            val listRequest = buildJsonObject {
-                                put("jsonrpc", "2.0")
-                                put("method", "resources/list")
-                                put("id", 2)
-                            }
-                            
-                            send(Frame.Text(listRequest.toString()))
-                            
-                            val response = incoming.receive() as Frame.Text
-                            val json = Json.parseToJsonElement(response.readText()).jsonObject
-                            val resources = json["result"]?.jsonObject?.get("resources")?.jsonArray
-                            
-                            resources?.size shouldBeGreaterThan 0
-                            resources?.any { 
-                                it.jsonObject["uri"]?.jsonPrimitive?.content == "cycletime://project/$projectId"
-                            } shouldBe true
-                        }
-                    }
-                }
-            }
-        }
-        
-        describe("Tool execution") {
-            it("should execute create project tool") {
+            it("should list available resources via POST") {
                 testApplication {
                     application {
                         configureDependencies()
                         configureMCP()
                     }
-                    
-                    client.webSocket("/mcp") {
-                        MCPTestHelper.initialize(this)
-                        
-                        val toolCall = buildJsonObject {
+
+                    TestFixtures.withProject { projectId ->
+                        val client = createClient()
+
+                        val listRequest = buildJsonObject {
                             put("jsonrpc", "2.0")
-                            put("method", "tools/call")
-                            put("id", 3)
-                            put("params", buildJsonObject {
-                                put("name", "cycletime_create_project")
-                                put("arguments", buildJsonObject {
-                                    put("name", "Test Project")
-                                    put("description", "Created via MCP")
-                                })
-                            })
+                            put("method", "resources/list")
+                            put("id", 2)
                         }
-                        
-                        send(Frame.Text(toolCall.toString()))
-                        
-                        val response = incoming.receive() as Frame.Text
-                        val json = Json.parseToJsonElement(response.readText()).jsonObject
-                        val content = json["result"]?.jsonObject?.get("content")?.jsonArray?.first()
-                        val resultText = content?.jsonObject?.get("text")?.jsonPrimitive?.content
-                        val result = Json.parseToJsonElement(resultText ?: "{}").jsonObject
-                        
-                        result["success"]?.jsonPrimitive?.boolean shouldBe true
-                        result["project"]?.jsonObject?.get("name")?.jsonPrimitive?.content shouldBe "Test Project"
+
+                        val response = client.post("/mcp") {
+                            contentType(ContentType.Application.Json)
+                            setBody(listRequest.toString())
+                        }
+
+                        val json = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+                        val resources = json["result"]?.jsonObject?.get("resources")?.jsonArray
+
+                        resources?.size shouldBeGreaterThan 0
+                        resources?.any {
+                            it.jsonObject["uri"]?.jsonPrimitive?.content == "cycletime://project/$projectId"
+                        } shouldBe true
                     }
+                }
+            }
+        }
+
+        describe("Tool execution") {
+            it("should execute create project tool via POST") {
+                testApplication {
+                    application {
+                        configureDependencies()
+                        configureMCP()
+                    }
+
+                    val client = createClient()
+
+                    val toolCall = buildJsonObject {
+                        put("jsonrpc", "2.0")
+                        put("method", "tools/call")
+                        put("id", 3)
+                        put("params", buildJsonObject {
+                            put("name", "create_project")
+                            put("arguments", buildJsonObject {
+                                put("name", "Test Project")
+                                put("description", "Created via MCP")
+                            })
+                        })
+                    }
+
+                    val response = client.post("/mcp") {
+                        contentType(ContentType.Application.Json)
+                        setBody(toolCall.toString())
+                    }
+
+                    val json = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+                    val content = json["result"]?.jsonObject?.get("content")?.jsonArray?.first()
+                    val resultText = content?.jsonObject?.get("text")?.jsonPrimitive?.content
+                    val result = Json.parseToJsonElement(resultText ?: "{}").jsonObject
+
+                    result["success"]?.jsonPrimitive?.boolean shouldBe true
+                    result["project"]?.jsonObject?.get("name")?.jsonPrimitive?.content shouldBe "Test Project"
+                }
+            }
+        }
+
+        describe("EventBus integration") {
+            it("should deliver events via SSE stream") {
+                testApplication {
+                    application {
+                        configureDependencies()
+                        configureMCP()
+                    }
+
+                    val client = createClient()
+                    val eventBus = EventBus()
+
+                    // Launch SSE listener in background
+                    val events = mutableListOf<String>()
+                    launch {
+                        val response = client.get("/mcp/events") {
+                            header(HttpHeaders.Accept, "text/event-stream")
+                        }
+                        // Collect SSE events (in real implementation)
+                    }
+
+                    // Publish event via EventBus
+                    eventBus.publish(Event(
+                        sessionId = "test-session",
+                        data = """{"jsonrpc":"2.0","result":{"success":true}}"""
+                    ))
+
+                    // Events should be delivered through SSE stream
                 }
             }
         }
@@ -1139,78 +1224,201 @@ class MCPServerTest : DescribeSpec({
 })
 ```
 
+### Manual Testing with curl
+
+Testing the SSE + POST dual-endpoint architecture with command-line tools:
+
+```bash
+# Terminal 1: Establish SSE connection (server-to-client events)
+curl -N http://localhost:8080/mcp/events
+
+# Terminal 2: Send JSON-RPC requests via POST (client-to-server)
+
+# 1. Initialize protocol
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2024-11-05",
+      "clientInfo": {
+        "name": "curl-client",
+        "version": "1.0.0"
+      }
+    }
+  }'
+
+# 2. List available tools
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+# 3. List available resources
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"resources/list"}'
+
+# 4. Execute tool (create project)
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "tools/call",
+    "params": {
+      "name": "create_project",
+      "arguments": {
+        "name": "Test Project",
+        "description": "Created via curl"
+      }
+    }
+  }'
+
+# 5. Read resource
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 5,
+    "method": "resources/read",
+    "params": {
+      "uri": "cycletime://projects"
+    }
+  }'
+
+# All responses appear in Terminal 1 via SSE event stream
+```
+
 ### Mock MCP Client
 
 ```kotlin
 // src/test/kotlin/io/spiralhouse/cycletime/testing/mocks/MockMCPClient.kt
 
-import io.ktor.websocket.*
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.serialization.json.*
 
 /**
- * Mock MCP client for testing
+ * Mock MCP client for testing SSE + POST endpoints
  */
-class MockMCPClient {
-    private val responses = Channel<JsonRpcResponse>()
+class MockMCPClient(
+    private val client: HttpClient,
+    private val sseUrl: String = "http://localhost:8080/mcp/events",
+    private val postUrl: String = "http://localhost:8080/mcp"
+) {
+    private val events = Channel<String>(Channel.UNLIMITED)
     private var requestId = 1
-    
+
+    /**
+     * Establish SSE connection to receive server events
+     */
+    suspend fun connectSSE() {
+        val response = client.get(sseUrl) {
+            header(HttpHeaders.Accept, "text/event-stream")
+        }
+        // Process SSE events in background
+    }
+
+    /**
+     * Send initialize request via POST
+     */
     suspend fun initialize(): JsonRpcResponse {
-        val request = JsonRpcRequest(
-            method = "initialize",
-            params = buildJsonObject {
-                put("protocolVersion", "1.0")
+        val request = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("method", "initialize")
+            put("id", requestId++)
+            put("params", buildJsonObject {
+                put("protocolVersion", "2024-11-05")
                 put("clientInfo", buildJsonObject {
                     put("name", "mock-client")
                     put("version", "1.0")
                 })
-            },
-            id = JsonPrimitive(requestId++)
-        )
-        
-        // Simulate server response
-        return JsonRpcResponse(
-            jsonrpc = "2.0",
-            id = request.id,
-            result = buildJsonObject {
-                put("protocolVersion", "1.0")
-                put("serverInfo", buildJsonObject {
-                    put("name", "CycleTime MCP Server")
-                    put("version", "1.0.0")
-                })
-            }
-        )
-    }
-    
-    suspend fun listResources(): List<ResourceDescriptor> {
-        val request = JsonRpcRequest(
-            method = "resources/list",
-            id = JsonPrimitive(requestId++)
-        )
-        
-        // Mock response
-        return listOf(
-            ResourceDescriptor(
-                uri = "cycletime://projects",
-                name = "All Projects",
-                description = "List of all projects"
-            )
-        )
-    }
-    
-    suspend fun readResource(uri: String): ResourceContent {
-        return ResourceContent(
-            uri = uri,
-            mimeType = "application/json",
-            text = "{\"mock\": \"data\"}"
-        )
-    }
-    
-    suspend fun callTool(name: String, arguments: JsonObject): JsonObject {
-        return buildJsonObject {
-            put("success", true)
-            put("result", "mock result")
+            })
         }
+
+        val response = client.post(postUrl) {
+            contentType(ContentType.Application.Json)
+            setBody(request.toString())
+        }
+
+        return Json.decodeFromString(response.bodyAsText())
+    }
+
+    /**
+     * List resources via POST
+     */
+    suspend fun listResources(): List<ResourceDescriptor> {
+        val request = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("method", "resources/list")
+            put("id", requestId++)
+        }
+
+        val response = client.post(postUrl) {
+            contentType(ContentType.Application.Json)
+            setBody(request.toString())
+        }
+
+        val jsonResponse = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        val resources = jsonResponse["result"]?.jsonObject?.get("resources")?.jsonArray
+
+        return resources?.map {
+            Json.decodeFromJsonElement<ResourceDescriptor>(it)
+        } ?: emptyList()
+    }
+
+    /**
+     * Read resource via POST
+     */
+    suspend fun readResource(uri: String): ResourceContent {
+        val request = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("method", "resources/read")
+            put("id", requestId++)
+            put("params", buildJsonObject {
+                put("uri", uri)
+            })
+        }
+
+        val response = client.post(postUrl) {
+            contentType(ContentType.Application.Json)
+            setBody(request.toString())
+        }
+
+        val jsonResponse = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        val contents = jsonResponse["result"]?.jsonObject?.get("contents")?.jsonArray
+
+        return contents?.firstOrNull()?.let {
+            Json.decodeFromJsonElement<ResourceContent>(it)
+        } ?: ResourceContent(uri, "application/json", "{}")
+    }
+
+    /**
+     * Call tool via POST
+     */
+    suspend fun callTool(name: String, arguments: JsonObject): JsonObject {
+        val request = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("method", "tools/call")
+            put("id", requestId++)
+            put("params", buildJsonObject {
+                put("name", name)
+                put("arguments", arguments)
+            })
+        }
+
+        val response = client.post(postUrl) {
+            contentType(ContentType.Application.Json)
+            setBody(request.toString())
+        }
+
+        val jsonResponse = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        return jsonResponse["result"]?.jsonObject ?: buildJsonObject {}
     }
 }
 ```
@@ -1323,9 +1531,11 @@ class MCPMetrics(
 
 This MCP integration provides:
 - **Full MCP Protocol Support**: Resources, Tools, and Prompts
-- **WebSocket Transport**: Real-time bidirectional communication
+- **SSE Transport**: Server-Sent Events for server-to-client streaming with dual-endpoint architecture
+- **Dual-Endpoint Architecture**: SSE stream (GET /mcp/events) for server-to-client events, POST endpoint (POST /mcp) for client-to-server requests
 - **JSON-RPC 2.0**: Standard protocol implementation
+- **EventBus Pattern**: Event-driven message delivery through SSE streams
 - **DI Integration**: Clean dependency injection
-- **Comprehensive Testing**: Unit and integration tests
+- **Comprehensive Testing**: Unit and integration tests with SSE + POST patterns
 - **Performance Monitoring**: Metrics and observability
 - **Error Handling**: Robust error management

--- a/docs/reference/technical-design/mcp-integration-patterns.md
+++ b/docs/reference/technical-design/mcp-integration-patterns.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document outlines the Model Context Protocol (MCP) integration patterns for CycleTime, enabling seamless communication with Claude Code through WebSocket connections and JSON-RPC messaging. The implementation leverages Ktor's WebSocket support and dependency injection for maintainable, testable MCP server components.
+This document outlines the Model Context Protocol (MCP) integration patterns for CycleTime, enabling seamless communication with Claude Code through SSE (Server-Sent Events) transport and JSON-RPC messaging. The implementation leverages Ktor's SSE support and dependency injection for maintainable, testable MCP server components.
 
 ## MCP Protocol Overview
 
@@ -11,7 +11,8 @@ This document outlines the Model Context Protocol (MCP) integration patterns for
 - **Resources**: Read-only data exposed to Claude Code (projects, issues, contexts)
 - **Tools**: Executable functions Claude Code can invoke (create, update, delete operations)
 - **Prompts**: Pre-configured prompt templates for common workflows
-- **WebSocket Transport**: Real-time bidirectional communication
+- **SSE Transport**: Server-Sent Events for server-to-client streaming
+- **POST Requests**: Client-to-server JSON-RPC requests
 - **JSON-RPC 2.0**: Standard request/response protocol
 
 ### Protocol Flow
@@ -19,19 +20,18 @@ This document outlines the Model Context Protocol (MCP) integration patterns for
 ```
 Claude Code                    CycleTime MCP Server
     |                               |
-    |-------- WebSocket Connect --->|
+    |------- SSE Connect (/mcp/events) -->|
     |                               |
-    |<------- Initialize Request ---|
-    |-------- Initialize Response ->|
+    |<------ SSE Stream Established ---|
     |                               |
-    |<------- Resources List -------|
-    |<------- Tools List ------------|
+    |-- POST /mcp (Initialize) ----->|
+    |<------ Initialize Response -----|
     |                               |
-    |-------- Resource Read -------->|
-    |<------- Resource Content ------|
+    |-- POST /mcp (Resources List) ->|
+    |<------ Resources via SSE -------|
     |                               |
-    |-------- Tool Execute --------->|
-    |<------- Tool Result -----------|
+    |-- POST /mcp (Tool Execute) ---->|
+    |<------ Tool Result via SSE ------|
     |                               |
 ```
 
@@ -40,17 +40,17 @@ Claude Code                    CycleTime MCP Server
 ```kotlin
 // build.gradle.kts
 dependencies {
-    // Ktor WebSocket support
-    implementation("io.ktor:ktor-server-websockets:3.2.0")
-    implementation("io.ktor:ktor-server-content-negotiation:3.2.0")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:3.2.0")
-    
+    // Ktor SSE support
+    implementation("io.ktor:ktor-server-sse:3.2.3")
+    implementation("io.ktor:ktor-server-content-negotiation:3.2.3")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.2.3")
+
     // JSON-RPC implementation
     implementation("com.github.kotlin-json-rpc:json-rpc:1.0.0")
-    
+
     // Coroutines for async handling
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
-    
+
     // Serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 }
@@ -64,12 +64,14 @@ dependencies {
 // src/main/kotlin/io/spiralhouse/cycletime/infrastructure/mcp/CycleTimeMCPServer.kt
 
 import io.ktor.server.application.*
-import io.ktor.server.websocket.*
-import io.ktor.websocket.*
+import io.ktor.server.response.*
+import io.ktor.server.request.*
+import io.ktor.server.routing.*
+import io.ktor.server.sse.*
+import io.ktor.sse.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.json.*
-import java.time.Duration
 
 /**
  * Main MCP server coordinating resources and tools
@@ -81,55 +83,64 @@ class CycleTimeMCPServer(
 ) {
     private val logger = LoggerFactory.getLogger(CycleTimeMCPServer::class.java)
     private val sessions = mutableMapOf<String, MCPSession>()
-    
+
     /**
-     * Initialize MCP server with WebSocket endpoint
+     * Initialize MCP server with SSE and POST endpoints
      */
     fun Application.configureMCP() {
-        install(WebSockets) {
-            pingPeriod = Duration.ofSeconds(15)
-            timeout = Duration.ofSeconds(15)
-            maxFrameSize = Long.MAX_VALUE
-            masking = false
-        }
-        
+        install(SSE)
+
         routing {
-            webSocket("/mcp") {
-                handleMCPConnection(this)
+            // SSE endpoint for server-to-client events
+            sse("/mcp/events") {
+                handleSSEConnection(this)
+            }
+
+            // POST endpoint for client-to-server requests
+            post("/mcp") {
+                handlePostRequest(call)
             }
         }
     }
-    
+
     /**
-     * Handle incoming MCP WebSocket connection
+     * Handle incoming MCP SSE connection
      */
-    private suspend fun handleMCPConnection(session: WebSocketSession) {
+    private suspend fun handleSSEConnection(session: ServerSentEventSession) {
         val sessionId = generateSessionId()
         val mcpSession = MCPSession(sessionId, session)
         sessions[sessionId] = mcpSession
-        
+
         try {
-            logger.info("MCP client connected: $sessionId")
-            
-            // Handle incoming messages
-            for (frame in session.incoming) {
-                when (frame) {
-                    is Frame.Text -> {
-                        val text = frame.readText()
-                        handleJsonRpcMessage(mcpSession, text)
-                    }
-                    is Frame.Close -> {
-                        logger.info("MCP client disconnected: $sessionId")
-                        break
-                    }
-                    else -> {} // Ignore other frame types
-                }
+            logger.info("MCP SSE client connected: $sessionId")
+
+            // Send keep-alive events
+            while (true) {
+                session.send(ServerSentEvent("ping"))
+                kotlinx.coroutines.delay(30000) // 30 second keep-alive
             }
         } catch (e: Exception) {
-            logger.error("Error in MCP session $sessionId", e)
+            logger.error("Error in MCP SSE session $sessionId", e)
         } finally {
             sessions.remove(sessionId)
             mcpSession.close()
+        }
+    }
+
+    /**
+     * Handle incoming POST requests
+     */
+    private suspend fun handlePostRequest(call: ApplicationCall) {
+        try {
+            val message = call.receiveText()
+            val jsonElement = Json.parseToJsonElement(message)
+            val request = Json.decodeFromJsonElement<JsonRpcRequest>(jsonElement)
+
+            val response = processJsonRpcRequest(request)
+            call.respond(response)
+        } catch (e: Exception) {
+            logger.error("Error processing POST request", e)
+            call.respond(createErrorResponse(e))
         }
     }
     

--- a/docs/reference/technical-design/mcp-mvp-spike-plan.md
+++ b/docs/reference/technical-design/mcp-mvp-spike-plan.md
@@ -1,5 +1,7 @@
 # MCP MVP Implementation Plan - 1-Day Spike
 
+> **Historical Note**: This document describes the WebSocket-based MCP implementation that was superseded by SSE (Server-Sent Events) transport in SPI-665 (October 2025). CycleTime now uses SSE transport following MCP specification v2024-11-05. For current implementation details, see [MCP Client Setup](../../getting-started/mcp-client-setup.md) and [MCP Integration Patterns](mcp-integration-patterns.md).
+
 ## Executive Summary
 
 **Critical Discovery**: MCP is not optional infrastructure but THE PRIMARY USER INTERFACE for CycleTime. 90% of user interactions will be through Claude Code via MCP, not the web dashboard.

--- a/docs/reference/technical-design/testing-architecture-tdd.md
+++ b/docs/reference/technical-design/testing-architecture-tdd.md
@@ -525,82 +525,83 @@ class ProjectApiTest : DescribeSpec({
 })
 ```
 
-### WebSocket Testing
+### SSE Testing
 
 ```kotlin
-// src/test/kotlin/io/spiralhouse/cycletime/mcp/MCPWebSocketTest.kt
+// src/test/kotlin/io/spiralhouse/cycletime/mcp/MCPSSETest.kt
 
-import io.ktor.client.plugins.websocket.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.server.testing.*
-import io.ktor.websocket.*
+import io.ktor.http.*
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.*
 
-class MCPWebSocketTest : DescribeSpec({
-    
-    describe("MCP WebSocket") {
-        
-        it("should handle MCP handshake") {
+class MCPSSETest : DescribeSpec({
+
+    describe("MCP SSE") {
+
+        it("should handle MCP initialization via POST") {
             testApplication {
                 application {
                     configureDependencies()
                     configureMCP()
                 }
-                
-                client.webSocket("/mcp") {
-                    // Send initialize request
-                    val initRequest = buildJsonObject {
-                        put("jsonrpc", "2.0")
-                        put("method", "initialize")
-                        put("id", 1)
-                        put("params", buildJsonObject {
-                            put("protocolVersion", "1.0")
-                            put("clientInfo", buildJsonObject {
-                                put("name", "test-client")
-                                put("version", "1.0.0")
-                            })
+
+                // Send initialize request via POST
+                val initRequest = buildJsonObject {
+                    put("jsonrpc", "2.0")
+                    put("method", "initialize")
+                    put("id", 1)
+                    put("params", buildJsonObject {
+                        put("protocolVersion", "2024-11-05")
+                        put("clientInfo", buildJsonObject {
+                            put("name", "test-client")
+                            put("version", "1.0.0")
                         })
-                    }
-                    
-                    send(Frame.Text(initRequest.toString()))
-                    
-                    // Receive response
-                    val response = incoming.receive() as Frame.Text
-                    val responseJson = Json.parseToJsonElement(response.readText()).jsonObject
-                    
-                    responseJson["jsonrpc"]?.jsonPrimitive?.content shouldBe "2.0"
-                    responseJson["id"]?.jsonPrimitive?.int shouldBe 1
-                    responseJson["result"] shouldNotBe null
+                    })
                 }
+
+                val response = client.post("/mcp") {
+                    contentType(ContentType.Application.Json)
+                    setBody(initRequest.toString())
+                }
+
+                // Verify response
+                val responseJson = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+
+                responseJson["jsonrpc"]?.jsonPrimitive?.content shouldBe "2.0"
+                responseJson["id"]?.jsonPrimitive?.int shouldBe 1
+                responseJson["result"] shouldNotBe null
             }
         }
-        
-        it("should handle resource requests") {
+
+        it("should handle resource requests via POST") {
             testApplication {
                 TestFixtures.withProject { projectId ->
-                    client.webSocket("/mcp") {
-                        // Initialize first
-                        MCPTestHelper.initialize(this)
-                        
-                        // Request project resource
-                        val resourceRequest = buildJsonObject {
-                            put("jsonrpc", "2.0")
-                            put("method", "resources/read")
-                            put("id", 2)
-                            put("params", buildJsonObject {
-                                put("uri", "cycletime://project/$projectId")
-                            })
-                        }
-                        
-                        send(Frame.Text(resourceRequest.toString()))
-                        
-                        val response = incoming.receive() as Frame.Text
-                        val responseJson = Json.parseToJsonElement(response.readText()).jsonObject
-                        
-                        val result = responseJson["result"]?.jsonObject
-                        result?.get("contents")?.jsonArray?.isNotEmpty() shouldBe true
+                    // Initialize first
+                    MCPTestHelper.initializeViaPost(this)
+
+                    // Request project resource via POST
+                    val resourceRequest = buildJsonObject {
+                        put("jsonrpc", "2.0")
+                        put("method", "resources/read")
+                        put("id", 2)
+                        put("params", buildJsonObject {
+                            put("uri", "cycletime://project/$projectId")
+                        })
                     }
+
+                    val response = client.post("/mcp") {
+                        contentType(ContentType.Application.Json)
+                        setBody(resourceRequest.toString())
+                    }
+
+                    val responseJson = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+
+                    val result = responseJson["result"]?.jsonObject
+                    result?.get("contents")?.jsonArray?.isNotEmpty() shouldBe true
                 }
             }
         }

--- a/docs/testing/test-suites.md
+++ b/docs/testing/test-suites.md
@@ -25,7 +25,7 @@ The CycleTime project now uses three distinct test suites optimized for differen
 - **Database Isolation**: Each test gets its own H2 in-memory database instance
 - **Usage**: `./gradlew integrationTest`
 
-**MCP Test Coverage**: Includes MCP server infrastructure, WebSocket connections, and resource management tests (see `.claude/shared/testing-standards.md` for complete categorization)
+**MCP Test Coverage**: Includes MCP server infrastructure, SSE connections, and resource management tests (see `.claude/shared/testing-standards.md` for complete categorization)
 
 ### 3. System Tests (`systemTest`)
 - **Purpose**: End-to-end scenarios and performance validation


### PR DESCRIPTION
## Summary

Updated all 15 documentation files to reflect the SSE (Server-Sent Events) transport implementation that replaced WebSocket in SPI-665 for MCP specification v2024-11-05 compliance.

## Changes by Category

### User-Facing Documentation (2 files)
- ✅ `mcp-client-setup.md` - Complete SSE transport configuration guide with dual-endpoint architecture
- ✅ `mcp-testing.md` - Updated test procedures with SSE + POST examples

### Simple Updates (4 files)
- ✅ `PRD.md` - Updated architecture diagram to SSE transport
- ✅ `MVP_CAPABILITY_SUMMARY.md` - Changed WebSocket to SSE endpoint references
- ✅ `configuration-management.md` - Updated config with SSE environment variables
- ✅ `phase-2-reference.md` - Added historical superseded note

### Moderate Updates (6 files)
- ✅ `mcp-development.md` - Converted all wscat examples to curl for SSE
- ✅ `dependency-injection-patterns.md` - Updated DI examples for SSE routing
- ✅ `test-suites.md` - Changed test categorization to SSE connections
- ✅ `ci-cd/overview.md` - Updated CI test coverage for SSE endpoints
- ✅ `testing-standards.md` - Updated MCP infrastructure to SSE connections
- ✅ `project-structure.md` - Updated directory structure (websocket → sse)

### Complex Architectural Rewrites (3 files)
- ✅ `mcp-troubleshooting.md` - Complete rewrite of troubleshooting flows for SSE
- ✅ `mcp-integration-patterns.md` - Architectural rewrite for SSE pattern with dual endpoints
- ✅ `testing-architecture-tdd.md` - Updated test patterns for SSE transport

## Key Technical Changes

**Configuration Format**:
```json
// OLD: WebSocket
{
  "type": "websocket",
  "url": "ws://localhost:8080/mcp"
}

// NEW: SSE
{
  "type": "sse",
  "url": "http://localhost:8080/mcp/events"
}
```

**Architecture**: 
- Single WebSocket endpoint → Dual-endpoint architecture
- SSE endpoint: `http://localhost:8080/mcp/events` (server-to-client events)
- POST endpoint: `http://localhost:8080/mcp` (client-to-server requests)

**Environment Variables**:
- Removed: `MCP_PING_PERIOD`, `MCP_MAX_FRAME_SIZE`
- Added: `MCP_SSE_PATH`, `MCP_POST_PATH`

**Testing Tools**: 
- `wscat` → `curl` for testing SSE + POST endpoints

## Impact

All documentation now reflects:
- MCP specification v2024-11-05 compliance
- Dual-endpoint SSE architecture (SSE + POST)
- Correct configuration examples for Claude Code
- Updated troubleshooting procedures
- Accurate test patterns and procedures

## Related

- Implements documentation updates for: #134 (SPI-665)

🤖 Generated with [Claude Code](https://claude.com/claude-code)