### PR TITLE
ci: fix automated versioning by explicitly fetching tags (SPI-747)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true  # Explicitly fetch tags for git-semver-plugin
 
       - name: Setup JDK 21
         uses: actions/setup-java@v4
@@ -885,8 +886,8 @@ jobs:
     timeout-minutes: 10
     # Only create release for production versions on main branch
     if: |
-      github.ref == 'refs/heads/main' && 
-      needs.version.outputs.is_release == 'true' && 
+      github.ref == 'refs/heads/main' &&
+      needs.version.outputs.is_release == 'true' &&
       github.event.inputs.skip_release != 'true' &&
       needs.build.result == 'success'
 
@@ -895,6 +896,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true  # Explicitly fetch tags for changelog generation
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
## Summary

Fixes automated versioning in CI by explicitly fetching git tags for the semver plugin.

**Issue**: [SPI-747](https://linear.app/spiral-house/issue/SPI-747/fix-automated-versioning)

## Problem

The git-semver-plugin could not find the `v0.1.0` tag in CI, causing incorrect version calculation:

| Environment | Version Calculated | Issue |
|------------|-------------------|-------|
| **Local** | `0.2.0-SNAPSHOT+355` | ✅ Correct |
| **CI** | `0.1.0-SNAPSHOT+647` | ❌ Tag not found |

**Impact:**
- Version stuck at `0.1.0` despite 86 `feat:` + 104 `fix:` commits since v0.1.0
- Published containers stuck at `0.1.0-SNAPSHOT-647.sha.xxx`
- Commit count from repository root (647) instead of from tag (355)

## Root Cause

`actions/checkout@v4` has a [documented limitation](https://github.com/actions/checkout/issues/1471) where tags aren't fetched without explicit `fetch-tags: true`. The `fetch-depth: 0` parameter alone is insufficient.

## Solution

Added `fetch-tags: true` to checkout configuration in:
- **version job**: Version calculation with git-semver-plugin
- **release job**: Changelog generation needs tag history

```yaml
- name: Checkout
  uses: actions/checkout@v4
  with:
    fetch-depth: 0
    fetch-tags: true  # ← Fix
```

## Verification

**Local Testing:**
```bash
./gradlew printSemVersion
# Output: 0.2.0-SNAPSHOT+355.sha.997820d ✅
```

**CI Testing:**
- This PR will verify CI calculates `0.2.0-SNAPSHOT` correctly
- Watch the "Calculate Version" job output in CI

## Post-Merge Steps

After this PR merges:
1. Create `v0.2.0` tag to establish clean baseline:
   ```bash
   git tag -a v0.2.0 -m "Version 0.2.0 - Baseline for automated versioning"
   git push origin v0.2.0
   ```
2. Verify next commit increments to `0.2.1-SNAPSHOT`

## Investigation Details

Full root cause analysis completed by DevOps engineer with ultrathink reasoning:
- See Linear issue comments for complete investigation report
- Identified tag fetch issue as primary root cause
- Analyzed git-semver plugin behavior and GitHub Actions limitations
- Proposed remediation plan with testing strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)