### PR TITLE
fix(cicd): add tail -1 pipe to version calculation and workflow detection (SPI-908)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -111,7 +111,7 @@ jobs:
           if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
             echo "🤖 Dependabot PR detected - running full security validation pipeline"
             echo "run_tests=true" >> $GITHUB_OUTPUT
-          elif git diff --name-only HEAD~1 HEAD | grep -E '\.(kt|kts|java|gradle)$|src/|build\.gradle|settings\.gradle|gradle\.properties|gradle/.*\.toml|gradle/'; then
+          elif git diff --name-only HEAD~1 HEAD | grep -E '\.(kt|kts|java|gradle)$|src/|build\.gradle|settings\.gradle|gradle\.properties|gradle/.*\.toml|gradle/|\.github/workflows/'; then
             echo "✅ Code changes detected - will run full pipeline"
             echo "run_tests=true" >> $GITHUB_OUTPUT
           else
@@ -151,7 +151,8 @@ jobs:
           if [ "$should_tag" = true ]; then
             # Calculate next version using printCleanVersion task
             # This task strips SNAPSHOT and build metadata from git-semver-plugin output
-            next_version=$(./gradlew printCleanVersion --quiet --no-configuration-cache)
+            # Use 'tail -1' to get only the last line (handles Gradle wrapper download output edge case)
+            next_version=$(./gradlew printCleanVersion --quiet --no-configuration-cache | tail -1)
 
             if [[ -n "$next_version" && "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "📦 Creating tag: v$next_version"


### PR DESCRIPTION
## Summary

Fixes two critical issues in the CI/CD pipeline that broke release automation since v0.2.0:

1. **Version tag creation failure** - Missing `tail -1` pipe causes Gradle wrapper output to contaminate version string
2. **Workflow change detection** - CI/CD configuration changes not triggering full pipeline runs

## Root Cause Analysis

### Issue #1: Version Tag Creation Failure (CRITICAL)

**Problem**: Line 154 was missing the `tail -1` pipe that exists at line 235.

**Evidence**: Workflow logs showed multi-line Gradle wrapper download output instead of clean version number:
```
⚠️ Failed to calculate next version: Downloading https://services.gradle.org/distributions/gradle-9.1.0-bin.zip
............10%.............20%...............100%
0.3.0
⏭️ Skipping tag creation due to version calculation failure
```

**Root cause**: Gradle wrapper download progress contaminated the version string, failing regex validation `^[0-9]+\.[0-9]+\.[0-9]+$`

**Impact**: 5 commits since v0.2.0 (commit `ed72436`) failed to create version tags and GitHub releases:
- `b2cb6cb` → should be v0.3.0 (feat: soft-deletion stubs)
- `18c6bc4` → should be v0.3.1 (fix: printCleanVersion task)
- `4c9d40b` → should be v0.3.2 (fix: printCleanVersion migration)
- `695075f` → should be v0.3.3 (fix: artifact glob patterns)
- `3e65d40` → should be v0.4.0 (feat: Project soft-deletion)

### Issue #2: Workflow Change Detection (MEDIUM)

**Problem**: Changes to `.github/workflows/` not triggering full pipeline execution.

**Impact**: Workflow configuration changes treated as documentation-only commits, skipping test runs and artifact builds.

## Changes Made

### Fix #1: Add `tail -1` to Version Calculation (Line 154-155)

**Before**:
```yaml
next_version=$(./gradlew printCleanVersion --quiet --no-configuration-cache)
```

**After**:
```yaml
# Use 'tail -1' to get only the last line (handles Gradle wrapper download output edge case)
next_version=$(./gradlew printCleanVersion --quiet --no-configuration-cache | tail -1)
```

**Pattern source**: Matches proven working implementation at lines 234-235.

### Fix #2: Include Workflow Changes in Code Detection (Line 114)

**Before**:
```yaml
elif git diff --name-only HEAD~1 HEAD | grep -E '\.(kt|kts|java|gradle)$|src/|build\.gradle|settings\.gradle|gradle\.properties|gradle/.*\.toml|gradle/'; then
```

**After**:
```yaml
elif git diff --name-only HEAD~1 HEAD | grep -E '\.(kt|kts|java|gradle)$|src/|build\.gradle|settings\.gradle|gradle\.properties|gradle/.*\.toml|gradle/|\.github/workflows/'; then
```

**Rationale**: Ensures CI/CD configuration changes trigger full validation and artifact creation.

## Testing

- ✅ YAML syntax validated (no structural errors)
- ✅ Pattern matches working implementation at lines 234-235
- ✅ Workflow detection regex expanded to include `.github/workflows/`
- ⏳ **Validation on merge**: Merging to main will validate fix by creating v0.5.0 tag

## Expected Results

After merge to main:
- ✅ Version tag v0.5.0 created successfully
- ✅ GitHub release created with artifacts (JAR, native binaries)
- ✅ Workflow logs show "✅ Tag vX.Y.Z created successfully"
- ✅ Workflow logs show "✅ Tag vX.Y.Z pushed successfully"
- ✅ No Gradle wrapper download output in version string
- ✅ Regex validation passes for clean version number

## References

- **Linear Issue**: https://linear.app/spiral-house/issue/SPI-908
- **Failed Workflow Run**: https://github.com/spiralhouse/cycletime/actions/runs/19007286600
- **Broken Since**: v0.2.0 (commit `ed72436`)

## Acceptance Criteria

- [x] Fix #1: `tail -1` pipe added to version calculation
- [x] Fix #2: `.github/workflows/` added to code detection
- [x] YAML syntax validated
- [x] Commit follows conventional format
- [ ] Version tag created after merge to main
- [ ] GitHub release created with artifacts
- [ ] Workflow logs show successful tag creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)