### PR TITLE
fix(tests): eliminate order-dependent assertion in UnitOfWorkTransactionTest (SPI-909)

### DIFF
--- a/src/integrationTest/kotlin/io/spiralhouse/cycletime/integration/UnitOfWorkTransactionTest.kt
+++ b/src/integrationTest/kotlin/io/spiralhouse/cycletime/integration/UnitOfWorkTransactionTest.kt
@@ -244,7 +244,7 @@ class UnitOfWorkTransactionTest : DescribeSpec({
                 // After both transactions, both projects should exist
                 val allProjects = projectRepository.findAll()
                 allProjects shouldHaveSize 2
-                allProjects.map { it.id } shouldBe setOf(project1.id, project2.id)
+                allProjects.map { it.id }.toSet() shouldBe setOf(project1.id, project2.id)
             }
         }
     }


### PR DESCRIPTION
## Summary

Fix flaky integration test `UnitOfWorkTransactionTest` that was blocking main branch CI due to order-dependent assertion on non-deterministic database query results.

**Linear Issue**: https://linear.app/spiral-house/issue/SPI-909  
**Failed Workflow**: https://github.com/spiralhouse/cycletime/actions/runs/19007750869

## Root Cause Analysis

**File**: `src/integrationTest/kotlin/io/spiralhouse/cycletime/integration/UnitOfWorkTransactionTest.kt`  
**Line**: 247

**Problematic Code**:
```kotlin
// BEFORE (FLAKY)
allProjects.map { it.id } shouldBe setOf(project1.id, project2.id)
//          ↑ List (ordered)         ↑ Set→List (arbitrary order)
```

**Issue**:
- Left side: `allProjects.map { it.id }` returns `List<UUID>` with order from database query
- Right side: `setOf(...)` returns `Set<UUID>` converted to list by Kotest for comparison
- Database `findAll()` has **no ORDER BY clause** → non-deterministic ordering
- Test passed/failed randomly based on H2 query plan selection

**Error Pattern**:
```
org.opentest4j.AssertionFailedError: Element differ at index: [0, 1]
expected:<[uuid1, uuid2]> 
but was:<[uuid2, uuid1]>
```

## Solution

**Applied Fix**:
```kotlin
// AFTER (STABLE)
allProjects.map { it.id }.toSet() shouldBe setOf(project1.id, project2.id)
//                        ↑ Convert to Set for order-agnostic comparison
```

**Rationale**:
- Test verifies set membership (both projects exist), not ordering
- Converting both sides to `Set` makes comparison order-agnostic
- Matches semantic guarantee of code under test (no ordering promised)
- Complies with `.claude/shared/testing-standards.md`: "If order doesn't matter, don't test for it"

## Test Stability Verification

**Methodology**: Ran integration test suite 5 consecutive times with `--rerun-tasks` to verify stability

**Results**:
```
Run 1: BUILD SUCCESSFUL in 1m 2s  ✓ UnitOfWorkTransactionTest PASSED
Run 2: BUILD SUCCESSFUL in 1m 3s  ✓ UnitOfWorkTransactionTest PASSED
Run 3: BUILD SUCCESSFUL in 1m 3s  ✓ UnitOfWorkTransactionTest PASSED
Run 4: BUILD SUCCESSFUL in 1m 2s  ✓ UnitOfWorkTransactionTest PASSED
Run 5: BUILD SUCCESSFUL in 1m 2s  ✓ UnitOfWorkTransactionTest PASSED
```

**Specific Test Verification**:
- Target test: "should maintain isolation between concurrent transactions"
- Passed all 5 runs without failures
- Zero flakiness detected

## Audit Results

**Comprehensive File Scan**:
- Searched for similar patterns: `.map.*shouldBe`, `shouldBe setOf`, `shouldBe listOf`, `shouldContainExactly`
- **Only 1 instance found**: Line 247 (now fixed)
- All other `findAll()` assertions use `shouldHaveSize` or `forEach` (order-independent)
- No other order-dependent anti-patterns detected

## Impact

**Before**:
- Main branch CI randomly failing
- Blocks merges to main
- Intermittent failures causing developer confusion

**After**:
- Test is deterministic and stable
- No changes to business logic or production code
- Zero regression risk (test-only change)

## Testing Standards Compliance

Per `.claude/shared/testing-standards.md`:

✓ Tests must be deterministic and isolated  
✓ Assertions should match semantic guarantees of code under test  
✓ If order doesn't matter, don't test for it  
✓ No flaky time-dependent or order-dependent tests

## Checklist

- [x] Fix applied to line 247 using order-agnostic assertion
- [x] Integration tests run 5+ times locally without failures
- [x] Similar patterns audited in same test file
- [x] Zero additional order-dependent patterns found
- [x] Commit follows conventional commit format
- [x] Testing standards compliance verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)