### PR TITLE
fix(cicd): build and release all distribution artifacts (JAR, TAR, ZIP) (SPI-910)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -860,10 +860,10 @@ jobs:
           name: compiled-artifacts
           path: build/
 
-      - name: Build application JAR
+      - name: Build application JAR and distributions
         run: |
-          echo "🔨 Building application JAR for deployment (version: ${{ needs.version.outputs.version }})"
-          ./gradlew buildFatJar -x compileKotlin -x compileTestKotlin -x compileIntegrationTestKotlin -x compileSystemTestKotlin -x test --no-build-cache --configuration-cache --no-daemon
+          echo "🔨 Building application artifacts (version: ${{ needs.version.outputs.version }})"
+          ./gradlew buildFatJar assembleDist -x compileKotlin -x compileTestKotlin -x compileIntegrationTestKotlin -x compileSystemTestKotlin -x test --no-build-cache --configuration-cache --no-daemon
 
       - name: Verify JAR exists
         run: |
@@ -1075,14 +1075,14 @@ jobs:
           version="${{ needs.version.outputs.version }}"
           echo "🚀 Creating release for version: $version"
 
-          # Create release with artifacts (flat structure from download-artifact)
+          # Create release with artifacts (preserves subdirectories from upload-artifact@v4)
           gh release create "v$version" \
             --title "Release $version" \
             --notes "${{ steps.capture.outputs.changelog }}" \
             --target "${{ github.sha }}" \
-            build-artifacts/*.jar \
-            build-artifacts/*.tar \
-            build-artifacts/*.zip
+            build-artifacts/libs/*.jar \
+            build-artifacts/distributions/*.tar \
+            build-artifacts/distributions/*.zip
 
   # ========================================
   # VALIDATION & REPORTING


### PR DESCRIPTION
## Summary

Fixes GitHub release creation by building all distribution artifacts and correcting path patterns to match actual artifact download structure.

**Linear Issue**: [SPI-910 - Fix GitHub release creation with distribution artifacts](https://linear.app/spiral-house/issue/SPI-910)

## Problem

GitHub release creation was failing with "no matches found for `build-artifacts/*.jar`" error:

**Failed Workflow**: https://github.com/spiralhouse/cycletime/actions/runs/19008474592

### Three Contributing Factors

1. **Missing Distribution Build Step**: Build only ran `buildFatJar` which creates a single JAR. The `distTar` and `distZip` tasks that create .tar and .zip archives were never executed.

2. **Incorrect Path Assumptions**: SPI-892 (commit 695075f) incorrectly assumed `upload-artifact@v4` flattens directory structures. In reality, the v4 API preserves relative paths from the least common ancestor (LCA).

3. **No Validation**: Workflow uploaded `build/distributions/` even when it didn't exist, then assumed distribution files existed during release creation.

## Solution

Applied two fixes to `.github/workflows/cicd.yml`:

### Fix 1: Add `assembleDist` to Build Command (Line 866)

**Before:**
```yaml
- name: Build application JAR
  run: |
    echo "Building application JAR for deployment"
    ./gradlew buildFatJar -x compileKotlin ... --no-daemon
```

**After:**
```yaml
- name: Build application JAR and distributions
  run: |
    echo "Building application artifacts"
    ./gradlew buildFatJar assembleDist -x compileKotlin ... --no-daemon
```

### Fix 2: Update Release Paths to Match Actual Structure (Lines 1083-1085)

**Before:**
```yaml
# Create release with artifacts (flat structure from download-artifact)
gh release create "v$version" \
  --title "Release $version" \
  --notes "$CHANGELOG" \
  --target "$GITHUB_SHA" \
  build-artifacts/*.jar \
  build-artifacts/*.tar \
  build-artifacts/*.zip
```

**After:**
```yaml
# Create release with artifacts (preserves subdirectories from upload-artifact@v4)
gh release create "v$version" \
  --title "Release $version" \
  --notes "$CHANGELOG" \
  --target "$GITHUB_SHA" \
  build-artifacts/libs/*.jar \
  build-artifacts/distributions/*.tar \
  build-artifacts/distributions/*.zip
```

## Validation

### Local Build Test Results

```bash
./gradlew clean buildFatJar assembleDist -x test --no-daemon
```

**All artifacts created successfully:**
- JAR: `build/libs/cycletime-server.jar` (41M)
- TAR: `build/distributions/cycletime-0.3.2-SNAPSHOT.tar` (41M)
- ZIP: `build/distributions/cycletime-0.3.2-SNAPSHOT.zip` (37M)

### Artifact Structure Analysis

The `upload-artifact@v4` action preserves the directory structure:

```
build-artifacts/
├── libs/
│   └── cycletime-server.jar
└── distributions/
    ├── cycletime-0.3.2-SNAPSHOT.tar
    └── cycletime-0.3.2-SNAPSHOT.zip
```

This structure is preserved in the downloaded artifact, requiring the subdirectory paths in the `gh release create` command.

## Impact

**Positive:**
- Enables automated release creation with all distribution formats
- Aligns with SPI-892's stated intent to release JAR, TAR, and ZIP artifacts
- Fixes critical blocker preventing releases on main branch

**No Breaking Changes:**
- Workflow behavior remains the same for all other stages
- Additional build task adds ~5 seconds to build job
- No changes to container or deployment stages

## Acceptance Criteria

All criteria from SPI-910 will be met:
- [x] Distribution archives (JAR, TAR, ZIP) are built during CI (validated locally)
- [x] All three artifact types uploaded to workflow artifacts (verified via path patterns)
- [ ] GitHub release created successfully with all artifacts (requires CI run)
- [ ] Release artifacts downloadable and functional (requires CI run)
- [ ] Workflow logs show successful release creation (requires CI run)
- [ ] No "no matches found" errors in release job (requires CI run)

## Testing Strategy

**Pre-merge validation:**
1. CI will run on this branch
2. Build job will create all three artifact types
3. Container job will verify JAR still works as expected

**Post-merge validation (on main):**
1. Full pipeline will run including release creation
2. Release job will create GitHub release with v0.3.2 (or next version)
3. Verify all three artifacts are attached to the release
4. Download and test each artifact type

## References

- **Linear Issue**: SPI-910
- **Failed Workflow**: https://github.com/spiralhouse/cycletime/actions/runs/19008474592
- **Related**: SPI-892 (original release artifact changes)
- **Related**: SPI-908 (version tagging - confirmed working)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
