### PR TITLE
docs(spi-1188): update MCP Kotlin SDK version references to v0.7.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Currently using H2 with Exposed ORM (migrated from SQLite in SPI-439).
 - **GraalVM**: Native image compilation support
 
 ### MCP Integration
-- **MCP Kotlin SDK v0.7.2**: Official SDK for Model Context Protocol
+- **MCP Kotlin SDK v0.7.6**: Official SDK for Model Context Protocol
 - **Maintainers**: Anthropic and JetBrains
 - **Transport**: Ktor integration with SSE + JSON-RPC
 - **Session Management**: Stateless per-request with database persistence

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -336,7 +336,7 @@ CycleTime implements the Streamable HTTP transport per MCP specification (2025-0
 | Phase | Transport | Status |
 |-------|-----------|--------|
 | Legacy EventBus | Custom SSE + POST | Removed (SPI-707) |
-| MCP SDK v0.7.2 | SSE Transport | Removed (SPI-763) |
+| MCP SDK v0.7.6 | SSE Transport | Removed (SPI-763) |
 | Streamable HTTP | POST + SSE at /mcp | Current (SPI-759) |
 
 Benefits: MCP spec compliance, Claude Code v2.0.25+ support, security controls, simplified architecture.

--- a/docs/guides/development/mcp-development.md
+++ b/docs/guides/development/mcp-development.md
@@ -9,7 +9,7 @@ keywords: [mcp, development, server, tools, resources, sdk, protocol]
 estimated_time: 30 minutes
 difficulty: advanced
 status: complete
-last_updated: 2025-10-20
+last_updated: 2025-11-20
 ---
 
 # MCP Development Guide
@@ -87,7 +87,7 @@ flowchart TD
 
 ## MCP Server Implementation Patterns
 
-CycleTime uses the official **MCP Kotlin SDK v0.7.2** maintained by Anthropic and JetBrains. The server integrates with Ktor using a custom Streamable HTTP transport handler.
+CycleTime uses the official **MCP Kotlin SDK v0.7.6** maintained by Anthropic and JetBrains. The server integrates with Ktor using a custom Streamable HTTP transport handler.
 
 ### Server Architecture
 

--- a/docs/guides/getting-started/mcp-client-setup-guide.md
+++ b/docs/guides/getting-started/mcp-client-setup-guide.md
@@ -8,7 +8,7 @@ related: [configuration-guide.md, ../../reference/troubleshooting.md]
 keywords: [mcp, client, setup, claude-code, streamable-http, connection]
 estimated_time: 15 minutes
 difficulty: intermediate
-last_updated: 2025-10-27
+last_updated: 2025-11-20
 ---
 
 # MCP Client Setup
@@ -25,12 +25,12 @@ Before configuring the MCP client connection, ensure you have:
 
 ## Connection Overview
 
-CycleTime uses the official MCP Kotlin SDK v0.7.2 with a custom Streamable HTTP transport handler. Claude Code connects to the `/mcp` endpoint for real-time project data access and tool execution.
+CycleTime uses the official MCP Kotlin SDK v0.7.6 with a custom Streamable HTTP transport handler. Claude Code connects to the `/mcp` endpoint for real-time project data access and tool execution.
 
 ```mermaid
 sequenceDiagram
     participant CC as Claude Code
-    participant SDK as MCP SDK (v0.7.2)
+    participant SDK as MCP SDK (v0.7.6)
     participant Server as CycleTime Server
     participant DB as Project Database
 
@@ -102,7 +102,7 @@ MCP_PORT=3006 MCP_HOST=127.0.0.1 MCP_DETAILED_LOGGING=true ./gradlew run
 | `MCP_DETAILED_LOGGING` | `false` | Enable debug-level logging |
 | `MCP_METRICS_ENABLED` | `true` | Enable metrics collection |
 
-**Note**: SDK v0.7.2 uses Streamable HTTP transport at `/mcp` endpoint. Legacy SSE transport at root endpoint (`/`) has been removed (SPI-763).
+**Note**: SDK v0.7.6 uses Streamable HTTP transport at `/mcp` endpoint. Legacy SSE transport at root endpoint (`/`) has been removed (SPI-763).
 
 ## Claude Code Configuration
 

--- a/docs/patterns/mcp/streamable-http-transport-pattern.md
+++ b/docs/patterns/mcp/streamable-http-transport-pattern.md
@@ -32,11 +32,11 @@ MCP moved from SSE (Server-Sent Events) to Streamable HTTP transport:
 
 **Current Implementation**: Custom Streamable HTTP handler (SPI-759, SPI-763)
 - SSE transport removed in SPI-763
-- Custom handler built on Ktor to bridge to MCP Kotlin SDK v0.7.2
+- Custom handler built on Ktor to bridge to MCP Kotlin SDK v0.7.6
 - Single `/mcp` endpoint supporting both POST and GET methods
 
 **Why Custom Handler?**
-The MCP Kotlin SDK v0.7.2 does not yet provide server-side Streamable HTTP transport with Ktor (open PR blocked by Ktor routing DSL limitations). CycleTime implements a custom handler that will migrate to official SDK support when available.
+The MCP Kotlin SDK v0.7.6 does not yet provide server-side Streamable HTTP transport with Ktor (open PR blocked by Ktor routing DSL limitations). CycleTime implements a custom handler that will migrate to official SDK support when available.
 
 ## Streamable HTTP Architecture in CycleTime
 

--- a/docs/reference/project-fundamentals.md
+++ b/docs/reference/project-fundamentals.md
@@ -6,7 +6,7 @@ description: "Essential project knowledge shared across all agents and contribut
 keywords: [technology-stack, architecture, linear, package-structure, conventions]
 dependencies: []
 related: [../architecture/overview.md, ./PRD.md, ./user-experience.md]
-last_updated: 2025-10-21
+last_updated: 2025-11-20
 ---
 
 # Project Fundamentals
@@ -32,7 +32,7 @@ CycleTime CE (Community Edition) is a project orchestration framework that exten
 
 ### MCP Integration
 
-- **MCP Kotlin SDK v0.7.2**: Official SDK for Model Context Protocol
+- **MCP Kotlin SDK v0.7.6**: Official SDK for Model Context Protocol
 - **Maintainers**: Anthropic and JetBrains
 - **Transport**: Ktor integration with SSE + JSON-RPC
 - **Session Management**: Stateless per-request with database persistence


### PR DESCRIPTION
## Summary

Updates all active documentation to reflect the MCP Kotlin SDK upgrade from v0.7.4 to v0.7.6 following merge of Dependabot PR #205.

## Changes

Updated SDK version references in 6 documentation files:
- CLAUDE.md
- docs/reference/project-fundamentals.md  
- docs/architecture/overview.md
- docs/patterns/mcp/streamable-http-transport-pattern.md
- docs/guides/development/mcp-development.md
- docs/guides/getting-started/mcp-client-setup-guide.md

All references updated from v0.7.2/v0.7.4 → v0.7.6. YAML frontmatter preserved, `last_updated` dates refreshed where applicable.

## Impact Analysis

**Risk Level**: LOW ✅

### SDK Changes (0.7.4 → 0.7.6)
- **v0.7.5**: Tool error handling fix, memory leak fix, FeatureRegistry migration, logging improvements
- **v0.7.6**: Coroutine cancellation fix, Gradle update

### Compatibility Assessment
- ✅ All tests passing (unit + integration)
- ✅ No breaking changes
- ✅ Code already compliant with SDK changes
- ✅ Benefits from bug fixes (error handling, memory, coroutines)

### Codebase Validation
Our adapter pattern and abstraction layers successfully isolated us from SDK internal changes while allowing us to benefit from stability improvements.

### Future Opportunities
- Consider leveraging `_meta` field for enhanced tool metadata/tracing
- Enable logging capability (SPI-716) when ready - SDK fix now available
- Monitor memory metrics to confirm session leak fix benefits

## Testing

No code changes required - documentation only update. Comprehensive impact analysis document available at `/tmp/mcp-sdk-upgrade-impact-analysis.md`.

## Related Issues

Implements SPI-1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)