### PR TITLE
ci(spi-1254): fix macOS-13 runner retirement causing native build failures

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -825,7 +825,7 @@ jobs:
             os: macos-14
             artifact_name: macos-aarch64
           - name: macOS x86_64
-            os: macos-13
+            os: macos-15-intel
             artifact_name: macos-x86_64
           - name: Linux x86_64
             os: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes the native build pipeline failure on main branch caused by GitHub retiring the macOS-13 runner images on December 15, 2025.

## Changes

- Replace `macos-13` with `macos-15-intel` in native build matrix (line 828 of `.github/workflows/cicd.yml`)
- Maintains macOS x86_64 architecture support for native binaries
- Single line change - minimal risk

## Root Cause

The macOS-13 runner pool was retired by GitHub Actions, causing the native-build job to fail immediately before compilation could start. This blocked the release pipeline since GitHub Release creation depends on successful native-build completion.

**GitHub Announcement:**
> The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046

## Impact

**Before:**
- ❌ macOS x86_64 native builds failing (retired runner)
- ❌ GitHub Release job blocked (dependency failure)
- ✅ Container builds and tests unaffected

**After:**
- ✅ All three native build platforms working:
  - Linux x86_64 (ubuntu-latest)
  - macOS ARM64 (macos-14)
  - macOS x86_64 (macos-15-intel)
- ✅ GitHub Release job unblocked
- ✅ Dev deployment pipeline restored

## Testing

Once merged to main:
1. Native build jobs should start successfully on all three platforms
2. GitHub Release job can execute (no longer blocked by native-build dependency)
3. Release artifacts include native binaries for all platforms

## References

- **Linear Issue:** [SPI-1254](https://linear.app/spiral-house/issue/SPI-1254)
- **Failed CI Run:** https://github.com/spiralhouse/cycletime/actions/runs/20319145246/job/58371215010
- **GitHub Runner Retirement:** https://github.com/actions/runner-images/issues/13046

## Acceptance Criteria

- [x] macOS x86_64 native build uses `macos-15-intel` runner
- [ ] All three native build platforms complete successfully (will verify in CI)
- [ ] GitHub Release job can execute (will verify after merge to main)
- [ ] Pipeline passes on main branch (will verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)