### PR TITLE
ci(spi-1258): fix GraalVM native build G1 GC configuration for Community Edition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -728,9 +728,10 @@ graalvmNative {
             // Performance optimizations
             buildArgs.add("-Ob") // Balanced optimization (size vs speed)
             buildArgs.add("-march=compatibility") // Cross-platform compatibility
-            buildArgs.add("--gc=G1") // G1 garbage collector for server workloads
+            // Serial GC is the default for GraalVM Community Edition
+            // G1 GC requires Oracle GraalVM (Enterprise) and is not available in CE
 
-            // Memory configuration
+            // Memory configuration (Serial GC tuning)
             buildArgs.add("-H:+UnlockExperimentalVMOptions")
             buildArgs.add("-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime")
 


### PR DESCRIPTION
## Summary

Fixes native image build failures on all platforms by removing G1 garbage collector configuration incompatible with GraalVM Community Edition.

## Changes

**File**: `build.gradle.kts` (lines 728-735)

- ❌ Removed: `buildArgs.add("--gc=G1")`
- ✅ Added: Explanatory comments about Serial GC being the default for CE
- ✅ Retained: Serial GC tuning parameters (CollectionPolicy$BySpaceAndTime)

## Root Cause

Native image builds explicitly requested G1 GC via `--gc=G1` flag, but GraalVM Community Edition only supports `serial` and `epsilon` garbage collectors. G1 GC requires Oracle GraalVM Enterprise Edition.

**Error Message:**
```
Error: In user 'G1' is not a valid value for the option --gc. 
Supported values are 'epsilon', 'serial'.
```

## Solution

Use the default Serial GC, which is appropriate for CycleTime's MCP server use case:

| Aspect | Serial GC (Now) | G1 GC (Was Requested) |
|--------|-----------------|----------------------|
| **Availability** | Community + Enterprise | Enterprise only |
| **Default Heap** | 80% of physical memory | 25% of physical memory |
| **Pause Times** | Stop-the-world | Shorter, incremental |
| **Throughput** | High for small-medium heaps | Optimized for large heaps |
| **Best For** | CycleTime's use case ✅ | Very large heap servers |

## Performance Implications

For CycleTime (MCP server with moderate memory requirements):
- ✅ Serial GC provides excellent performance for server workloads with small-medium heaps
- ✅ Default heap (80% of physical memory) is better for most deployments
- ✅ Stop-the-world GC pauses are acceptable for non-latency-critical request/response pattern
- ✅ High throughput suitable for CycleTime's workload

## Impact

**Before:**
- ❌ All three native build platforms failing
- ❌ GitHub Release job blocked
- ❌ Native binaries unavailable

**After:**
- ✅ All three platforms can build successfully:
  - Linux x86_64 (ubuntu-latest)
  - macOS ARM64 (macos-14)
  - macOS x86_64 (macos-15-intel)
- ✅ GitHub Release job unblocked
- ✅ Native binaries available for all platforms

## Testing

Once merged, CI will verify:
- Native builds complete on all three platforms
- Smoke tests pass (server starts, health checks respond)
- Native binaries created with Serial GC (default)

## Backward Compatibility

| Component | Impact |
|-----------|--------|
| JAR builds | No impact - uses JVM GC |
| Docker containers | No impact - uses JAR |
| Native binaries | Now builds with Serial GC |
| Runtime behavior | Minor GC behavior differences (acceptable) |

## References

- **Linear Issue**: [SPI-1258](https://linear.app/spiral-house/issue/SPI-1258)
- **Failed CI Run**: https://github.com/spiralhouse/cycletime/actions/runs/20347693419
- **GraalVM Memory Management**: https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/MemoryManagement/
- **Native Image Options**: https://www.graalvm.org/latest/reference-manual/native-image/overview/Options/

## Related Issues

This PR completes the native build fixes started in PR #232 (SPI-1254), which fixed the macOS runner retirement issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)