### PR TITLE
ci(spi-1259): fix GraalVM native image Logback reflection configuration

### DIFF
--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -82,8 +82,59 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"ch.qos.logback.classic.AsyncAppender",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"ch.qos.logback.core.AsyncAppenderBase",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"ch.qos.logback.core.rolling.RollingFileAppender",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"ch.qos.logback.core.FileAppender",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"ch.qos.logback.core.rolling.TimeBasedRollingPolicy",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"ch.qos.logback.core.rolling.RollingPolicyBase",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"ch.qos.logback.core.rolling.helper.TimeBasedArchiveRemover",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"ch.qos.logback.core.rolling.DefaultTimeBasedFileNamingAndTriggeringPolicy",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name":"ch.qos.logback.core.rolling.TimeBasedFileNamingAndTriggeringPolicyBase",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
   "name":"ch.qos.logback.core.OutputStreamAppender",
-  "methods":[{"name":"setEncoder","parameterTypes":["ch.qos.logback.core.encoder.Encoder"] }]
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
 },
 {
   "name":"ch.qos.logback.core.encoder.Encoder",


### PR DESCRIPTION
## Problem

Native binaries built successfully but crashed at runtime with:
```
ClassNotFoundException: ch.qos.logback.classic.AsyncAppender
```

This is the third consecutive CI failure after:
1. ✅ SPI-1254: Fixed macOS-13 runner retirement (PR #232)
2. ✅ SPI-1258: Removed G1 GC flag incompatible with Community Edition (PR #233)
3. 🔄 SPI-1259: This PR - Logback reflection configuration

## Root Cause

GraalVM's native image compilation uses closed-world assumption. Classes loaded dynamically at runtime (via Logback's XML configuration) must be explicitly registered for reflection.

Logback configuration (`src/main/resources/logback.xml`) references:
- `ch.qos.logback.classic.AsyncAppender`
- `ch.qos.logback.core.rolling.RollingFileAppender`
- `ch.qos.logback.core.rolling.TimeBasedRollingPolicy`

These classes and their parent classes require reflection registration.

## Solution

Added 10 Logback classes to `src/main/resources/META-INF/native-image/reflect-config.json`:

**Appenders:**
- `ch.qos.logback.classic.AsyncAppender`
- `ch.qos.logback.core.AsyncAppenderBase` (parent)
- `ch.qos.logback.core.rolling.RollingFileAppender`
- `ch.qos.logback.core.FileAppender` (parent)

**Rolling Policies:**
- `ch.qos.logback.core.rolling.TimeBasedRollingPolicy`
- `ch.qos.logback.core.rolling.RollingPolicyBase` (parent)
- `ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy`

**Support Classes:**
- `ch.qos.logback.core.rolling.helper.TimeBasedArchiveRemover`
- `ch.qos.logback.core.rolling.DefaultTimeBasedFileNamingAndTriggeringPolicy`
- `ch.qos.logback.core.rolling.TimeBasedFileNamingAndTriggeringPolicyBase` (parent)

Each class registered with:
- `allDeclaredMethods: true`
- `allDeclaredConstructors: true`

## Verification

**Local testing completed:**

```bash
# Native compilation
./gradlew nativeCompile
# Result: BUILD SUCCESSFUL

# Runtime test
./build/native/nativeCompile/cycletime-server
# Result: Server starts cleanly

# Health check
curl http://localhost:8080/health
# Result: 200 OK {"status":"HEALTHY"}

# No Logback errors in logs
# ✅ AsyncAppender initialized successfully
# ✅ RollingFileAppender configured
```

**File ignored by .gitignore:**
- Used `git add -f` to force-add `src/main/resources/META-INF/native-image/reflect-config.json`
- File was previously ignored but is required for native builds

## Testing

CI will verify:
- ✅ Linux x86_64 native build and smoke tests
- ✅ macOS ARM64 native build and smoke tests
- ✅ macOS x86_64 native build and smoke tests
- ✅ GitHub Release job unblocked

## Related Issues

- Fixes SPI-1259
- Unblocks GitHub Release workflow
- Completes third CI failure fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>