### PR TITLE
fix(ci): use PORT environment variable instead of --server.port CLI argument

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -925,8 +925,8 @@ jobs:
         run: |
           echo "🧪 Running smoke tests on native binary..."
 
-          # Start server in background
-          $BINARY_PATH --server.port=38080 > smoke-test.log 2>&1 &
+          # Start server in background (using PORT env var, not CLI args)
+          PORT=38080 $BINARY_PATH > smoke-test.log 2>&1 &
           SERVER_PID=$!
 
           echo "Server PID: $SERVER_PID"


### PR DESCRIPTION
## Problem

After fixing the Logback reflection configuration in PR #234, smoke tests still fail because the server ignores the `--server.port` argument:

```bash
# Smoke test tries to use:
$BINARY_PATH --server.port=38080

# But server starts on port 8080 (default)
# Smoke test waits 30 seconds trying to connect to localhost:38080
# Result: timeout failure
```

**From the CI logs:**
```
2025-12-19 09:38:10.366 [DefaultDispatcher-worker-1] INFO  io.ktor.server.Application - Responding at http://0.0.0.0:8080
❌ Server failed to start within 30 seconds
```

The server started successfully in 0.949 seconds, but on the wrong port!

## Root Cause

`Application.kt` only reads environment variables, NOT command-line arguments:

```kotlin
fun main() {
    val port = System.getenv("PORT")?.toIntOrNull() ?: 8080  // ENV var only!
    val host = System.getenv("HOST") ?: "0.0.0.0"
```

The `--server.port=38080` argument is completely ignored.

## Solution

Changed smoke test to use PORT environment variable:

```diff
- $BINARY_PATH --server.port=38080 > smoke-test.log 2>&1 &
+ PORT=38080 $BINARY_PATH > smoke-test.log 2>&1 &
```

## Testing

This change:
- ✅ Server will start on port 38080 (via PORT env var)
- ✅ Smoke tests will connect to localhost:38080
- ✅ Health checks will pass immediately
- ✅ MCP endpoint tests will pass
- ✅ All three platforms (Linux x86_64, macOS ARM64, macOS x86_64) will pass smoke tests

## Related Issues

- Follow-up to PR #234 (SPI-1259 Logback reflection fix)
- Part of the fourth consecutive CI failure fix series:
  1. ✅ SPI-1254: macOS-13 runner retirement (PR #232)
  2. ✅ SPI-1258: G1 GC removal (PR #233)
  3. ✅ SPI-1259: Logback reflection config (PR #234)
  4. 🔄 This PR: Smoke test PORT configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>