### PR TITLE
ci(spi-1268): fix release notes generation using explicit git-cliff tag

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1240,7 +1240,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --verbose --latest --strip header
+          args: --verbose --tag v${{ needs.version.outputs.version }} --strip header
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}
@@ -1330,21 +1330,39 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version="${{ needs.version.outputs.version }}"
-          echo "🚀 Creating release for version: $version"
+          echo "🚀 Creating/updating release for version: $version"
 
-          # Create release with artifacts (JAR + native binaries + checksums)
-          gh release create "v$version" \
-            --draft \
-            --title "Release $version" \
-            --notes "${{ steps.capture.outputs.changelog }}" \
-            --target "${{ github.sha }}" \
-            build-artifacts/libs/*.jar \
-            build-artifacts/distributions/*.tar \
-            build-artifacts/distributions/*.zip \
-            native-binaries/cycletime-server-* \
-            native-binaries/checksums-sha256.txt
+          # Check if release already exists
+          if gh release view "v$version" &>/dev/null; then
+            echo "Release v$version exists, updating notes..."
+            gh release edit "v$version" \
+              --notes "${{ steps.capture.outputs.changelog }}"
 
-          echo "✅ Release v$version created with JAR and native binaries"
+            # Upload artifacts (will replace existing ones)
+            gh release upload "v$version" \
+              --clobber \
+              build-artifacts/libs/*.jar \
+              build-artifacts/distributions/*.tar \
+              build-artifacts/distributions/*.zip \
+              native-binaries/cycletime-server-* \
+              native-binaries/checksums-sha256.txt
+
+            echo "✅ Release v$version updated with new notes and artifacts"
+          else
+            echo "Creating new release v$version..."
+            gh release create "v$version" \
+              --draft \
+              --title "Release $version" \
+              --notes "${{ steps.capture.outputs.changelog }}" \
+              --target "${{ github.sha }}" \
+              build-artifacts/libs/*.jar \
+              build-artifacts/distributions/*.tar \
+              build-artifacts/distributions/*.zip \
+              native-binaries/cycletime-server-* \
+              native-binaries/checksums-sha256.txt
+
+            echo "✅ Release v$version created with JAR and native binaries"
+          fi
 
   # ========================================
   # VALIDATION & REPORTING


### PR DESCRIPTION
## Problem

GitHub Release v0.4.0 (draft) has two critical issues:

1. **Duplicate entries**: Contains commits that already appear in v0.3.0 release (e.g., "docs: Refactor design system documentation into DAG structure (SPI-857) (#168)")
2. **Incorrect header**: Shows `[0.3.0] - 2025-12-04` instead of `[0.4.0] - current-date`

## Root Cause

The `git-cliff` action uses `--latest` flag which determines the tag range based on the *current* git tag state, not the specific release being created:

```yaml
# Current (problematic) - cicd.yml:1243
args: --verbose --latest --strip header
```

**Timeline:**
- v0.4.0 tag created: Dec 9, 2025
- v0.3.0 release recreated: Dec 10, 2025
- When v0.3.0 was recreated, git-cliff saw v0.4.0 as latest and generated v0.3.2→v0.4.0 range

## Changes

### 1. Use Explicit Tag in git-cliff (Line 1243)

```yaml
# Before
args: --verbose --latest --strip header

# After  
args: --verbose --tag v${{ needs.version.outputs.version }} --strip header
```

This ensures git-cliff generates changelog for the specific version being released, regardless of what other tags exist.

### 2. Add Idempotent Release Handling (Lines 1328-1365)

Added check before creating releases:

```bash
if gh release view "v$version" &>/dev/null; then
  # Update existing release
  gh release edit "v$version" --notes "..."
  gh release upload "v$version" --clobber artifacts/*
else
  # Create new release
  gh release create "v$version" --draft ...
fi
```

**Benefits:**
- Prevents failures when release already exists
- Allows updating release notes and artifacts
- Supports manual release recreation workflow

## Post-Merge Cleanup Required

After this PR merges, manual cleanup is needed:

```bash
# 1. Delete corrupted v0.4.0 draft
gh release delete v0.4.0 --yes

# 2. Backfill v0.3.1 release (commits from v0.3.0 to v0.3.1)
git-cliff v0.3.0..v0.3.1 --strip header | gh release create v0.3.1 \
  --title "Release 0.3.1" \
  --notes-file - \
  --target $(git rev-parse v0.3.1)

# 3. Backfill v0.3.2 release (commits from v0.3.1 to v0.3.2)
git-cliff v0.3.1..v0.3.2 --strip header | gh release create v0.3.2 \
  --title "Release 0.3.2" \
  --notes-file - \
  --target $(git rev-parse v0.3.2)

# 4. Next CI run will regenerate v0.4.0 correctly
```

## Verification

After fix and cleanup:
- ✅ v0.3.0: Contains commits from v0.2.0 to v0.3.0
- ✅ v0.3.1: Contains commits from v0.3.0 to v0.3.1 (backfilled)
- ✅ v0.3.2: Contains commits from v0.3.1 to v0.3.2 (backfilled)
- ✅ v0.4.0: Contains commits from v0.3.2 to v0.4.0 (regenerated correctly)
- ✅ No duplicate entries between any releases
- ✅ All version headers match actual versions

## Testing

CI will verify:
- Workflow syntax is valid
- No breaking changes to release job

Manual testing after merge will confirm release notes are generated correctly.

## Related Issues

- Fixes SPI-1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>