### PR TITLE
ci(spi-1270): fix cumulative changelog causing duplicate entries in GitHub releases

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1235,12 +1235,31 @@ jobs:
           fetch-depth: 0
           fetch-tags: true  # Explicitly fetch tags for changelog generation
 
+      - name: Compute changelog range
+        id: range
+        run: |
+          version="${{ needs.version.outputs.version }}"
+          echo "🔍 Computing changelog range for version $version..."
+
+          # Try to find previous tag
+          if previous_tag=$(git describe --tags --abbrev=0 "v${version}^" 2>/dev/null); then
+            echo "✅ Found previous tag: $previous_tag"
+            echo "range=${previous_tag}..v${version}" >> $GITHUB_OUTPUT
+          else
+            # First release: use range from initial commit
+            echo "⚠️  No previous tag found, using initial commit"
+            initial_commit=$(git rev-list --max-parents=0 HEAD)
+            echo "range=${initial_commit}..v${version}" >> $GITHUB_OUTPUT
+          fi
+
+          echo "📊 Changelog range: $(cat $GITHUB_OUTPUT | grep range= | cut -d= -f2)"
+
       - name: Generate changelog with git-cliff
         id: git-cliff
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --verbose --tag v${{ needs.version.outputs.version }} --strip header
+          args: --verbose --strip header ${{ steps.range.outputs.range }}
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Problem

Despite PRs #236 and #237 fixing git-cliff invocation and bash injection, v0.4.0 release still contains duplicate entries from previous versions:

**Current v0.4.0 structure:**
```
## [0.4.0] - 2025-12-20  ← Correct v0.4.0 changes
## [0.3.0] - 2025-12-04  ← Historical entries (DUPLICATES!)
## [0.2.0] - 2025-10-25  ← Historical entries (DUPLICATES!)
```

**Result**: SPI-857 and other commits appear in BOTH v0.3.0 AND v0.4.0 releases.

## Root Cause

Using `--tag v0.4.0` generates **cumulative changelog** (all history up to tag), not just commits since the previous tag:

```yaml
# Current (generates cumulative history)
git-cliff --tag v0.4.0 --strip header
# Output: v0.4.0 section + v0.3.0 section + v0.2.0 section
```

## Solution

Use commit **range** to generate ONLY commits for this release:

```yaml
# Proposed (generates single version)
git-cliff v0.3.2..v0.4.0 --strip header
# Output: v0.4.0 section ONLY
```

## Implementation

### 1. Added "Compute changelog range" step

Dynamically computes the range based on version:

- **Normal release**: Finds previous tag using `git describe --tags --abbrev=0 "v${version}^"`
- **First release**: Falls back to initial commit using `git rev-list --max-parents=0 HEAD`

### 2. Modified git-cliff invocation

Changed from `--tag v${version}` to positional range argument `${{ steps.range.outputs.range }}`.

## Verification

**Test 1: Normal release (v0.4.0)**
```bash
# Find range
previous_tag=$(git describe --tags --abbrev=0 "v0.4.0^")
# Output: v0.3.2

# Generate changelog
git-cliff v0.3.2..v0.4.0 --strip header | grep -c "## \["
# Output: 1 (v0.4.0 only) ✅
```

**Test 2: First release (v0.1.0)**
```bash
# No previous tag found, use initial commit
initial_commit=$(git rev-list --max-parents=0 HEAD)
git-cliff ${initial_commit}..v0.1.0 --strip header | grep -c "## \["
# Output: 1 (v0.1.0 only) ✅
```

## After Merge

The next release will contain ONLY its own commits, eliminating all duplicate entries across all future releases.

Fixes SPI-1270
