### PR TITLE
ci(spi-1274): fix git-cliff changelog range to use HEAD instead of non-existent tag

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1242,14 +1242,14 @@ jobs:
           echo "🔍 Computing changelog range for version $version..."
 
           # Try to find previous tag
-          if previous_tag=$(git describe --tags --abbrev=0 "v${version}^" 2>/dev/null); then
+          if previous_tag=$(git describe --tags --abbrev=0 HEAD 2>/dev/null); then
             echo "✅ Found previous tag: $previous_tag"
-            echo "range=${previous_tag}..v${version}" >> $GITHUB_OUTPUT
+            echo "range=${previous_tag}..HEAD" >> $GITHUB_OUTPUT
           else
             # First release: use range from initial commit
             echo "⚠️  No previous tag found, using initial commit"
             initial_commit=$(git rev-list --max-parents=0 HEAD)
-            echo "range=${initial_commit}..v${version}" >> $GITHUB_OUTPUT
+            echo "range=${initial_commit}..HEAD" >> $GITHUB_OUTPUT
           fi
 
           echo "📊 Changelog range: $(cat $GITHUB_OUTPUT | grep range= | cut -d= -f2)"


### PR DESCRIPTION
## Problem

After merging PR #239 (SPI-1273), the "Generate changelog with git-cliff" step continues to fail with:

```
Error: SetCommitRangeError("159e88806fbf87ab416da5d54de6c817124c6897..v0.4.0", Error { code: -3, klass: 4, message: "revspec 'v0.4.0' not found" })
```

## Root Cause

The workflow computes the changelog range using `v${version}` as the end of the range:

**Before (lines 1247, 1252):**
```bash
echo "range=${previous_tag}..v${version}" >> $GITHUB_OUTPUT
echo "range=${initial_commit}..v${version}" >> $GITHUB_OUTPUT
```

The problem is that `v${version}` is the tag that's about to be created - it doesn't exist yet at this point in the workflow. The tag creation happens **after** changelog generation in the release job.

## Solution

Use `HEAD` instead of `v${version}` since we want to generate the changelog from the last tag (or initial commit) to the current commit being released:

**After (this PR):**
```bash
echo "range=${previous_tag}..HEAD" >> $GITHUB_OUTPUT
echo "range=${initial_commit}..HEAD" >> $GITHUB_OUTPUT
```

Also changed line 1245 to use `git describe --tags --abbrev=0 HEAD` instead of `"v${version}^"` for consistency.

## Changes

- `.github/workflows/cicd.yml` (3 lines changed):
  - Line 1245: `git describe --tags --abbrev=0 HEAD` (was `"v${version}^"`)
  - Line 1247: `${previous_tag}..HEAD` (was `${previous_tag}..v${version}`)
  - Line 1252: `${initial_commit}..HEAD` (was `${initial_commit}..v${version}`)

## Testing

This fix will be verified when the next commit to main triggers the release workflow:
- Changelog generation should succeed without tag lookup errors
- Generated changelog should contain commits from last tag to HEAD
- Release should be created successfully with correct changelog content

## Impact

- **Risk**: Low - Simple reference change in git range
- **Value**: High - Unblocks entire release process
- **Related**: Part of the "Release Notes Saga" (SPI-1268, SPI-1269, SPI-1270, SPI-1273, SPI-1274)

Fixes SPI-1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)