### PR TITLE
fix(serialization): ensure consistent value class serialization in MCP responses (SPI-1277)

### DIFF
--- a/src/main/kotlin/io/spiralhouse/cycletime/application/dto/SessionDto.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/application/dto/SessionDto.kt
@@ -4,20 +4,31 @@ import io.spiralhouse.cycletime.domain.entities.Session
 import io.spiralhouse.cycletime.domain.entities.SessionContext
 import io.spiralhouse.cycletime.domain.valueobjects.ProjectId
 import io.spiralhouse.cycletime.domain.valueobjects.SessionKey
+import io.spiralhouse.cycletime.infrastructure.serialization.InstantSerializer
+import io.spiralhouse.cycletime.infrastructure.serialization.NullableProjectIdSerializer
+import io.spiralhouse.cycletime.infrastructure.serialization.SessionKeySerializer
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 /**
  * Data Transfer Object representing a Session for the application layer.
  * Used to transfer session data between layers without exposing domain entity internals.
+ *
+ * Uses custom serializers to ensure consistent primitive serialization for value classes.
+ * Related issue: SPI-1277
  */
 @Serializable
 data class SessionDto(
+    @Serializable(with = SessionKeySerializer::class)
     val sessionKey: SessionKey,
+    @Serializable(with = NullableProjectIdSerializer::class)
     val projectId: ProjectId?,
     val currentContext: SessionContext,
+    @Serializable(with = InstantSerializer::class)
     val lastActivity: Instant,
+    @Serializable(with = InstantSerializer::class)
     val createdAt: Instant,
+    @Serializable(with = InstantSerializer::class)
     val updatedAt: Instant
 ) {
     companion object {

--- a/src/main/kotlin/io/spiralhouse/cycletime/infrastructure/serialization/NullableValueObjectSerializers.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/infrastructure/serialization/NullableValueObjectSerializers.kt
@@ -2,6 +2,7 @@ package io.spiralhouse.cycletime.infrastructure.serialization
 
 import io.spiralhouse.cycletime.domain.valueobjects.IssueId
 import io.spiralhouse.cycletime.domain.valueobjects.ProjectId
+import io.spiralhouse.cycletime.domain.valueobjects.SessionKey
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -55,6 +56,34 @@ object NullableIssueIdSerializer : KSerializer<IssueId?> {
     override fun deserialize(decoder: Decoder): IssueId? {
         return if (decoder.decodeNotNullMark()) {
             IssueId.fromString(decoder.decodeString())
+        } else {
+            decoder.decodeNull()
+        }
+    }
+}
+
+/**
+ * Custom serializer for nullable SessionKey that ensures string serialization.
+ *
+ * Serializes nullable SessionKey as either a string (the UUID value) or null.
+ *
+ * Related issue: SPI-1277
+ */
+object NullableSessionKeySerializer : KSerializer<SessionKey?> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("io.spiralhouse.cycletime.domain.valueobjects.SessionKey?", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: SessionKey?) {
+        if (value == null) {
+            encoder.encodeNull()
+        } else {
+            encoder.encodeString(value.value)
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): SessionKey? {
+        return if (decoder.decodeNotNullMark()) {
+            SessionKey.fromString(decoder.decodeString())
         } else {
             decoder.decodeNull()
         }

--- a/src/main/kotlin/io/spiralhouse/cycletime/infrastructure/serialization/ValueObjectSerializers.kt
+++ b/src/main/kotlin/io/spiralhouse/cycletime/infrastructure/serialization/ValueObjectSerializers.kt
@@ -2,6 +2,7 @@ package io.spiralhouse.cycletime.infrastructure.serialization
 
 import io.spiralhouse.cycletime.domain.valueobjects.IssueId
 import io.spiralhouse.cycletime.domain.valueobjects.ProjectId
+import io.spiralhouse.cycletime.domain.valueobjects.SessionKey
 import io.spiralhouse.cycletime.domain.valueobjects.WorkflowId
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -65,5 +66,27 @@ object WorkflowIdSerializer : KSerializer<WorkflowId> {
 
     override fun deserialize(decoder: Decoder): WorkflowId {
         return WorkflowId.fromString(decoder.decodeString())
+    }
+}
+
+/**
+ * Custom serializer for SessionKey that ensures string serialization.
+ *
+ * Serializes SessionKey as a simple string (the UUID value) instead of a JSON object.
+ * This fixes the inconsistent serialization where value classes were sometimes being
+ * serialized as objects with "value" fields instead of primitive strings.
+ *
+ * Related issue: SPI-1277
+ */
+object SessionKeySerializer : KSerializer<SessionKey> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("io.spiralhouse.cycletime.domain.valueobjects.SessionKey", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: SessionKey) {
+        encoder.encodeString(value.value)
+    }
+
+    override fun deserialize(decoder: Decoder): SessionKey {
+        return SessionKey.fromString(decoder.decodeString())
     }
 }

--- a/src/systemTest/kotlin/io/spiralhouse/cycletime/system/mcp/session/SessionLifecycleE2ETest.kt
+++ b/src/systemTest/kotlin/io/spiralhouse/cycletime/system/mcp/session/SessionLifecycleE2ETest.kt
@@ -13,7 +13,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.spiralhouse.cycletime.test.utils.testSDKApplication
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -298,20 +297,9 @@ class SessionLifecycleE2ETest : StringSpec({
             val sessionData = Json.parseToJsonElement(textContent)
 
             // Verify session data matches (get_session returns SessionDto serialized as JSON)
-            // Handle value class serialization (might be primitive or object with "value" field)
-            val sessionKeyElement = sessionData.jsonObject["sessionKey"]
-            val returnedSessionKey = if (sessionKeyElement is JsonPrimitive) {
-                sessionKeyElement.content
-            } else {
-                sessionKeyElement?.jsonObject?.get("value")?.jsonPrimitive?.content
-            }
-
-            val projectIdElement = sessionData.jsonObject["projectId"]
-            val returnedProjectId = if (projectIdElement is JsonPrimitive) {
-                projectIdElement.content
-            } else {
-                projectIdElement?.jsonObject?.get("value")?.jsonPrimitive?.content
-            }
+            // Value classes now consistently serialize as primitives (SPI-1277 fix)
+            val returnedSessionKey = sessionData.jsonObject["sessionKey"]?.jsonPrimitive?.content
+            val returnedProjectId = sessionData.jsonObject["projectId"]?.jsonPrimitive?.content
 
             // Verify session key matches
             returnedSessionKey shouldBe sessionKey
@@ -746,19 +734,9 @@ class SessionLifecycleE2ETest : StringSpec({
             val session2Data = Json.parseToJsonElement(session2Content)
 
             // Verify second session has correct project (not inherited from first)
-            val session2KeyElement = session2Data.jsonObject["sessionKey"]
-            val session2Key = if (session2KeyElement is JsonPrimitive) {
-                session2KeyElement.content
-            } else {
-                session2KeyElement?.jsonObject?.get("value")?.jsonPrimitive?.content
-            }
-
-            val session2ProjectIdElement = session2Data.jsonObject["projectId"]
-            val session2ProjectId = if (session2ProjectIdElement is JsonPrimitive) {
-                session2ProjectIdElement.content
-            } else {
-                session2ProjectIdElement?.jsonObject?.get("value")?.jsonPrimitive?.content
-            }
+            // Value classes now consistently serialize as primitives (SPI-1277 fix)
+            val session2Key = session2Data.jsonObject["sessionKey"]?.jsonPrimitive?.content
+            val session2ProjectId = session2Data.jsonObject["projectId"]?.jsonPrimitive?.content
 
             session2Key shouldBe sessionKey2
             // Note: ProjectId might be null if session data doesn't include it
@@ -791,12 +769,8 @@ class SessionLifecycleE2ETest : StringSpec({
             val verifySession1Data = Json.parseToJsonElement(verifySession1Content)
 
             // Verify first session unchanged
-            val verify1SessionKeyElement = verifySession1Data.jsonObject["sessionKey"]
-            val verify1SessionKey = if (verify1SessionKeyElement is JsonPrimitive) {
-                verify1SessionKeyElement.content
-            } else {
-                verify1SessionKeyElement?.jsonObject?.get("value")?.jsonPrimitive?.content
-            }
+            // Value classes now consistently serialize as primitives (SPI-1277 fix)
+            val verify1SessionKey = verifySession1Data.jsonObject["sessionKey"]?.jsonPrimitive?.content
 
             verify1SessionKey shouldBe sessionKey1
             // Both sessions exist independently

--- a/src/test/kotlin/io/spiralhouse/cycletime/unit/serialization/SessionDtoSerializationTest.kt
+++ b/src/test/kotlin/io/spiralhouse/cycletime/unit/serialization/SessionDtoSerializationTest.kt
@@ -1,0 +1,178 @@
+package io.spiralhouse.cycletime.unit.serialization
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import io.spiralhouse.cycletime.application.dto.SessionDto
+import io.spiralhouse.cycletime.domain.entities.SessionContext
+import io.spiralhouse.cycletime.domain.valueobjects.ProjectId
+import io.spiralhouse.cycletime.domain.valueobjects.SessionKey
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Unit tests for SessionDto serialization.
+ *
+ * Verifies that SessionDto fields serialize correctly:
+ * - SessionKey as primitive string (not object with "value" field)
+ * - ProjectId as primitive string (not object with "value" field)
+ * - Instant fields as ISO-8601 strings
+ *
+ * This is the fix for SPI-1277 - inconsistent value class serialization.
+ */
+class SessionDtoSerializationTest : StringSpec({
+
+    val json = Json {
+        encodeDefaults = true
+        prettyPrint = false
+    }
+
+    val testSessionKey = "550e8400-e29b-41d4-a716-446655440000"
+    val testProjectId = "660e8400-e29b-41d4-a716-446655440001"
+    val now = Clock.System.now()
+
+    // ================================================================================
+    // SessionDto Serialization Tests
+    // ================================================================================
+
+    "SessionDto sessionKey should serialize as primitive string" {
+        val dto = SessionDto(
+            sessionKey = SessionKey(testSessionKey),
+            projectId = ProjectId.fromString(testProjectId),
+            currentContext = SessionContext(),
+            lastActivity = now,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        val serialized = json.encodeToString(SessionDto.serializer(), dto)
+        val jsonObj = json.parseToJsonElement(serialized).jsonObject
+
+        // sessionKey should be a JsonPrimitive, not an object
+        val sessionKeyElement = jsonObj["sessionKey"]
+        (sessionKeyElement is JsonPrimitive) shouldBe true
+        (sessionKeyElement as JsonPrimitive).content shouldBe testSessionKey
+
+        // Verify no "value" wrapper in the serialized output
+        serialized shouldNotContain """"sessionKey":{"value":"""
+    }
+
+    "SessionDto projectId should serialize as primitive string" {
+        val dto = SessionDto(
+            sessionKey = SessionKey(testSessionKey),
+            projectId = ProjectId.fromString(testProjectId),
+            currentContext = SessionContext(),
+            lastActivity = now,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        val serialized = json.encodeToString(SessionDto.serializer(), dto)
+        val jsonObj = json.parseToJsonElement(serialized).jsonObject
+
+        // projectId should be a JsonPrimitive, not an object
+        val projectIdElement = jsonObj["projectId"]
+        (projectIdElement is JsonPrimitive) shouldBe true
+        (projectIdElement as JsonPrimitive).content shouldBe testProjectId
+
+        // Verify no "value" wrapper in the serialized output
+        serialized shouldNotContain """"projectId":{"value":"""
+    }
+
+    "SessionDto null projectId should serialize as null" {
+        val dto = SessionDto(
+            sessionKey = SessionKey(testSessionKey),
+            projectId = null,
+            currentContext = SessionContext(),
+            lastActivity = now,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        val serialized = json.encodeToString(SessionDto.serializer(), dto)
+        val jsonObj = json.parseToJsonElement(serialized).jsonObject
+
+        // projectId should be null
+        val projectIdElement = jsonObj["projectId"]
+        projectIdElement shouldBe kotlinx.serialization.json.JsonNull
+    }
+
+    "SessionDto should not contain any value wrappers in serialized output" {
+        val dto = SessionDto(
+            sessionKey = SessionKey(testSessionKey),
+            projectId = ProjectId.fromString(testProjectId),
+            currentContext = SessionContext(),
+            lastActivity = now,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        val serialized = json.encodeToString(SessionDto.serializer(), dto)
+
+        // Ensure no value class object wrappers
+        serialized shouldNotContain """{"value":"""
+        serialized shouldNotContain """"_value":"""
+    }
+
+    "SessionDto round-trip serialization should work correctly" {
+        val original = SessionDto(
+            sessionKey = SessionKey(testSessionKey),
+            projectId = ProjectId.fromString(testProjectId),
+            currentContext = SessionContext(),
+            lastActivity = now,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        val serialized = json.encodeToString(SessionDto.serializer(), original)
+        val deserialized = json.decodeFromString(SessionDto.serializer(), serialized)
+
+        deserialized.sessionKey shouldBe original.sessionKey
+        deserialized.projectId shouldBe original.projectId
+        deserialized.lastActivity shouldBe original.lastActivity
+        deserialized.createdAt shouldBe original.createdAt
+        deserialized.updatedAt shouldBe original.updatedAt
+    }
+
+    "SessionDto with null projectId round-trip serialization" {
+        val original = SessionDto(
+            sessionKey = SessionKey(testSessionKey),
+            projectId = null,
+            currentContext = SessionContext(),
+            lastActivity = now,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        val serialized = json.encodeToString(SessionDto.serializer(), original)
+        val deserialized = json.decodeFromString(SessionDto.serializer(), serialized)
+
+        deserialized.sessionKey shouldBe original.sessionKey
+        deserialized.projectId shouldBe null
+    }
+
+    "SessionDto Instant fields should serialize as ISO-8601 strings" {
+        val dto = SessionDto(
+            sessionKey = SessionKey(testSessionKey),
+            projectId = null,
+            currentContext = SessionContext(),
+            lastActivity = now,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        val serialized = json.encodeToString(SessionDto.serializer(), dto)
+        val jsonObj = json.parseToJsonElement(serialized).jsonObject
+
+        // All Instant fields should be primitives (strings)
+        val lastActivity = jsonObj["lastActivity"]
+        val createdAt = jsonObj["createdAt"]
+        val updatedAt = jsonObj["updatedAt"]
+
+        (lastActivity is JsonPrimitive) shouldBe true
+        (createdAt is JsonPrimitive) shouldBe true
+        (updatedAt is JsonPrimitive) shouldBe true
+    }
+})

--- a/src/test/kotlin/io/spiralhouse/cycletime/unit/serialization/SessionKeySerializerTest.kt
+++ b/src/test/kotlin/io/spiralhouse/cycletime/unit/serialization/SessionKeySerializerTest.kt
@@ -1,0 +1,114 @@
+package io.spiralhouse.cycletime.unit.serialization
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import io.spiralhouse.cycletime.domain.valueobjects.SessionKey
+import io.spiralhouse.cycletime.infrastructure.serialization.NullableSessionKeySerializer
+import io.spiralhouse.cycletime.infrastructure.serialization.SessionKeySerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
+
+/**
+ * Unit tests for SessionKey serialization.
+ *
+ * Verifies that SessionKey serializes as a primitive string, not as an object
+ * with a "value" field. This is the fix for SPI-1277.
+ *
+ * ## Test Categories:
+ * 1. SessionKeySerializer - primitive string serialization
+ * 2. NullableSessionKeySerializer - null handling
+ * 3. Round-trip serialization
+ */
+class SessionKeySerializerTest : StringSpec({
+
+    val json = Json { encodeDefaults = true }
+    val testUuid = "550e8400-e29b-41d4-a716-446655440000"
+
+    // ================================================================================
+    // SessionKeySerializer Tests
+    // ================================================================================
+
+    "SessionKey should serialize as primitive string, not object" {
+        val sessionKey = SessionKey(testUuid)
+        val serialized = json.encodeToString(SessionKeySerializer, sessionKey)
+
+        // Should be just the UUID string, not an object
+        serialized shouldBe "\"$testUuid\""
+        serialized shouldNotContain "value"
+        serialized shouldNotContain "{"
+    }
+
+    "SessionKey should deserialize from primitive string" {
+        val jsonString = "\"$testUuid\""
+        val deserialized = json.decodeFromString(SessionKeySerializer, jsonString)
+
+        deserialized.value shouldBe testUuid
+    }
+
+    "SessionKey round-trip serialization should work correctly" {
+        val original = SessionKey.generate()
+        val serialized = json.encodeToString(SessionKeySerializer, original)
+        val deserialized = json.decodeFromString(SessionKeySerializer, serialized)
+
+        deserialized shouldBe original
+        deserialized.value shouldBe original.value
+    }
+
+    "SessionKey encodeToJsonElement should produce JsonPrimitive" {
+        val sessionKey = SessionKey(testUuid)
+        val element = json.encodeToJsonElement(SessionKeySerializer, sessionKey)
+
+        (element is JsonPrimitive) shouldBe true
+        (element as JsonPrimitive).content shouldBe testUuid
+    }
+
+    // ================================================================================
+    // NullableSessionKeySerializer Tests
+    // ================================================================================
+
+    "NullableSessionKeySerializer should serialize non-null value as primitive string" {
+        val sessionKey: SessionKey? = SessionKey(testUuid)
+        val serialized = json.encodeToString(NullableSessionKeySerializer, sessionKey)
+
+        serialized shouldBe "\"$testUuid\""
+        serialized shouldNotContain "value"
+    }
+
+    "NullableSessionKeySerializer should serialize null as null" {
+        val sessionKey: SessionKey? = null
+        val serialized = json.encodeToString(NullableSessionKeySerializer, sessionKey)
+
+        serialized shouldBe "null"
+    }
+
+    "NullableSessionKeySerializer should deserialize null" {
+        val deserialized = json.decodeFromString(NullableSessionKeySerializer, "null")
+
+        deserialized shouldBe null
+    }
+
+    "NullableSessionKeySerializer should deserialize non-null value" {
+        val deserialized = json.decodeFromString(NullableSessionKeySerializer, "\"$testUuid\"")
+
+        deserialized?.value shouldBe testUuid
+    }
+
+    "NullableSessionKeySerializer round-trip with non-null value" {
+        val original: SessionKey? = SessionKey.generate()
+        val serialized = json.encodeToString(NullableSessionKeySerializer, original)
+        val deserialized = json.decodeFromString(NullableSessionKeySerializer, serialized)
+
+        deserialized shouldBe original
+    }
+
+    "NullableSessionKeySerializer round-trip with null value" {
+        val original: SessionKey? = null
+        val serialized = json.encodeToString(NullableSessionKeySerializer, original)
+        val deserialized = json.decodeFromString(NullableSessionKeySerializer, serialized)
+
+        deserialized shouldBe null
+    }
+})


### PR DESCRIPTION
## Summary

- Fix inconsistent value class serialization in MCP responses where SessionKey and ProjectId sometimes serialized as primitives and sometimes as objects with a "value" field
- Add SessionKeySerializer for consistent primitive string serialization
- Update SessionDto with proper @Serializable(with=...) annotations
- Remove defensive parsing from E2E tests now that serialization is consistent

## Root Cause

`SessionDto` was missing custom serializer annotations that other DTOs (`ProjectDto`, `IssueDto`) correctly use. The `SessionKey` value class had no custom serializer, causing kotlinx.serialization to use default object serialization.

## Changes

### Core Implementation
- Add `SessionKeySerializer` in `ValueObjectSerializers.kt`
- Add `NullableSessionKeySerializer` in `NullableValueObjectSerializers.kt`
- Update `SessionDto` with serializer annotations for `sessionKey`, `projectId`, and `Instant` fields

### Testing
- Add `SessionKeySerializerTest` (10 unit tests)
- Add `SessionDtoSerializationTest` (7 unit tests)
- Update `SessionLifecycleE2ETest` to remove defensive parsing patterns

## Test plan

- [x] Run new serialization unit tests: `./gradlew test --tests "io.spiralhouse.cycletime.unit.serialization.*"` (17 tests pass)
- [x] Run E2E session tests: `./gradlew systemTest --tests "SessionLifecycleE2ETest"` (11 tests pass)
- [x] Run full check: `./gradlew check` (all tests pass, detekt passes)

## Related Issues

Resolves [SPI-1277](https://linear.app/spiral-house/issue/SPI-1277)

🤖 Generated with [Claude Code](https://claude.com/claude-code)