### PR TITLE
fix(cicd): pass version parameter to build job for clean artifact names (SPI-1295)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1076,7 +1076,7 @@ jobs:
       - name: Build application JAR and distributions
         run: |
           echo "🔨 Building application artifacts (version: ${{ needs.version.outputs.version }})"
-          ./gradlew buildFatJar assembleDist -x compileKotlin -x compileTestKotlin -x compileIntegrationTestKotlin -x compileSystemTestKotlin -x test --no-build-cache --configuration-cache --no-daemon
+          ./gradlew buildFatJar assembleDist -x compileKotlin -x compileTestKotlin -x compileIntegrationTestKotlin -x compileSystemTestKotlin -x test --no-build-cache --configuration-cache --no-daemon -Pversion=${{ needs.version.outputs.version }}
 
       - name: Verify JAR exists
         run: |


### PR DESCRIPTION
## Summary

Fixes SPI-1295 by ensuring JAR and distribution artifacts use clean semantic version without SNAPSHOT suffix.

## Problem

The v0.6.5 GitHub Release draft has SNAPSHOT-suffixed artifacts:
- `cycletime-0.6.5-SNAPSHOT.jar` (should be `cycletime-0.6.5.jar`)
- `cycletime-0.6.5-SNAPSHOT.tar` 
- `cycletime-0.6.5-SNAPSHOT.zip`

## Root Cause

The build job (`.github/workflows/cicd.yml` line 1079) doesn't pass `-Pversion=` parameter to Gradle, causing git-semver plugin to add SNAPSHOT suffix. Native build job already does this correctly (line 889).

## Changes

Add `-Pversion=${{ needs.version.outputs.version }}` parameter to `buildFatJar assembleDist` command to align with native-build job behavior.

## Expected Behavior After Fix

Once this merges and v0.6.5 tag is created:
- Artifacts: `cycletime-0.6.5.jar`, `cycletime-0.6.5.tar`, `cycletime-0.6.5.zip`
- Consistent versioning across all release artifacts
- No SNAPSHOT suffixes in production releases

## Test Plan

1. Merge this PR to main
2. Create git tag `v0.6.5` on main branch HEAD  
3. Delete existing draft release v0.6.5
4. Push tag to trigger release regeneration
5. Verify new release has clean artifact names

## References

- Linear Issue: SPI-1295
- Draft Release: https://github.com/spiralhouse/cycletime/releases/tag/untagged-9fda057826df39a887a4

🤖 Generated with [Claude Code](https://claude.com/claude-code)