### PR TITLE
fix(build): respect -Pversion parameter for version override (SPI-1295)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,12 @@ plugins {
 }
 
 group = "io.spiralhouse.cycletime"
-version = semver.version
+val explicitVersion = project.findProperty("version")?.toString()
+version = if (explicitVersion != null && explicitVersion != "unspecified") {
+    explicitVersion
+} else {
+    semver.version
+}
 
 // Git SemVersioning configuration (SPI-570: trigger CI for test result validation)
 // SPI-747: Removed defaultPreRelease = "SNAPSHOT" to enable automated releases


### PR DESCRIPTION
## Problem

PR #251 attempted to fix v0.6.5 release artifact naming by passing `-Pversion=0.6.5` to the build job in CI/CD workflow. However, artifacts still had SNAPSHOT suffix (e.g., `cycletime-0.6.6-SNAPSHOT.jar` instead of `cycletime-0.6.5.jar`).

## Root Cause

The issue was in `build.gradle.kts` line 17:

```kotlin
version = semver.version  // Hard-coded, ignores -Pversion parameter
```

When the CI/CD workflow runs:
1. Version calculated: `0.6.5` (from printCleanVersion)
2. Passed to build: `-Pversion=0.6.5`
3. Build immediately overwrites: `version = semver.version`
4. git-semver calculates: Latest tag (v0.6.5) + 1 commit = `0.6.6-SNAPSHOT`
5. Result: Artifacts named with wrong version

## Solution

Modified `build.gradle.kts` to respect the `-Pversion` parameter while maintaining backward compatibility:

```kotlin
val explicitVersion = project.findProperty("version")?.toString()
version = if (explicitVersion != null && explicitVersion != "unspecified") {
    explicitVersion  // Use CI/CD override
} else {
    semver.version  // Use git-semver for local builds
}
```

**Key insight**: Gradle has a default `version` property set to `"unspecified"`, so we must filter that out to properly detect explicit overrides.

## Testing

✅ **Local testing without parameter** (should use semver):
```bash
$ ./gradlew printVersion --quiet
0.6.6-SNAPSHOT
```

✅ **Local testing with parameter** (should use override):
```bash
$ ./gradlew printVersion -Pversion=0.6.5 --quiet
0.6.5
```

## Expected Impact

**CI/CD builds**:
- Command: `./gradlew build -Pversion=0.6.5`
- Result: `cycletime-0.6.5.jar` (clean version, no SNAPSHOT)

**Local builds**:
- Command: `./gradlew build`
- Result: `cycletime-0.6.6-SNAPSHOT.jar` (from git-semver, unchanged)

## Next Steps After Merge

1. Pull latest main
2. Delete existing draft release v0.6.5
3. Force-push v0.6.5 tag to trigger fresh build
4. Verify artifacts have clean names (no SNAPSHOT)
5. Verify changelog shows `## [0.6.5]` (not `[unreleased]`)
6. Mark SPI-1295 as Done

Fixes SPI-1295