### PR TITLE
fix(cicd): use --tag and --latest for correct changelog version header

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1233,25 +1233,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true  # Explicitly fetch tags for changelog generation
 
-      - name: Compute changelog range
-        id: range
-        run: |
-          version="${{ needs.version.outputs.version }}"
-          echo "🔍 Computing changelog range for version $version..."
-
-          # Try to find previous tag
-          if previous_tag=$(git describe --tags --abbrev=0 HEAD 2>/dev/null); then
-            echo "✅ Found previous tag: $previous_tag"
-            echo "range=${previous_tag}..HEAD" >> $GITHUB_OUTPUT
-          else
-            # First release: use range from initial commit
-            echo "⚠️  No previous tag found, using initial commit"
-            initial_commit=$(git rev-list --max-parents=0 HEAD)
-            echo "range=${initial_commit}..HEAD" >> $GITHUB_OUTPUT
-          fi
-
-          echo "📊 Changelog range: $(cat $GITHUB_OUTPUT | grep range= | cut -d= -f2)"
-
       - name: Remove existing changelog to prevent merge
         run: |
           echo "🗑️ Removing any existing CHANGELOG.md..."
@@ -1263,7 +1244,9 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --verbose --strip header ${{ steps.range.outputs.range }}
+          # --tag: Explicitly set version header (fixes "[unreleased]" bug from SPI-1295)
+          # --latest: Include commits since previous tag (handles edge cases correctly)
+          args: --verbose --strip header --tag ${{ needs.version.outputs.version }} --latest
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Problem

Release changelogs were showing `## [unreleased]` instead of the actual version (e.g., `## [0.6.6]`).

**Example of the bug** (v0.6.6 release before this fix):
```markdown
## [unreleased]

<!-- generated by git-cliff -->
```

## Root Cause

The "Compute changelog range" step had a bug:

```bash
# This returns the tag AT HEAD, not the PREVIOUS tag
if previous_tag=$(git describe --tags --abbrev=0 HEAD 2>/dev/null); then
    echo "range=${previous_tag}..HEAD" >> $GITHUB_OUTPUT
```

When HEAD is at a tag (e.g., v0.6.6):
1. `git describe --tags --abbrev=0 HEAD` returns `v0.6.6` (current tag, not previous)
2. Range becomes `v0.6.6..HEAD` which is **empty** (0 commits)
3. git-cliff has no commits to process, so `version` variable is unset
4. Template falls back to `## [unreleased]`

## Solution

Replace the buggy range calculation with git-cliff's built-in flags:

```yaml
# Before (buggy)
args: --verbose --strip header ${{ steps.range.outputs.range }}

# After (correct)
args: --verbose --strip header --tag ${{ needs.version.outputs.version }} --latest
```

**Why this works:**
- `--latest`: Automatically finds commits since the previous tag (handles all edge cases)
- `--tag $version`: Explicitly sets the version header (no more "[unreleased]")

## Testing

**Local verification:**
```bash
$ git-cliff --strip header --tag 0.6.6 --latest

## [0.6.6] - 2026-01-03

### 🐛 Bug Fixes
- **cicd**: Pass version parameter to build job...
- **build**: Respect -Pversion parameter...
...
```

**Comparison:**
| Before | After |
|--------|-------|
| `## [unreleased]` | `## [0.6.6] - 2026-01-03` |

## Changes

- Removed the buggy "Compute changelog range" step (20 lines deleted)
- Added `--tag` and `--latest` flags to git-cliff invocation
- Added comments explaining the flags (referencing SPI-1295)

## Related

- Fixes the "[unreleased]" header bug discovered in SPI-1295
- v0.6.6 release was manually fixed with the correct changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)